### PR TITLE
Update default checkout scheme to "wasm".

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -46,7 +46,7 @@
         "sourcekit-lsp": {
             "remote": { "id": "apple/sourcekit-lsp" } }
     },
-    "default-branch-scheme": "master",
+    "default-branch-scheme": "wasm",
     "branch-schemes": {
         "wasm": {
             "aliases": ["wasm"],


### PR DESCRIPTION
<!-- What's in this pull request? -->
Changes the default behavior of the `update-checkout` script to use the in the "wasm" scheme by default. While this change will never go into the master swift repo, in the meantime this should help people trying to build the fork.

Open to alternative ways of capturing this information if you want to consider alternatives solutions like additional documentation.