### PR TITLE
Avoid to emit inline asm for WebAssembly to build as debuggable

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -656,6 +656,10 @@ public:
   bool emitLifetimeExtendingUse(llvm::Value *Var) {
     llvm::Type *ArgTys;
     auto *Ty = Var->getType();
+    // Avoid to emit when Wasm because of lack of register.
+    if (IGM.TargetInfo.OutputObjectFormat == llvm::Triple::Wasm) {
+      return false;
+    }
     // Vectors, Pointers and Floats are expected to fit into a register.
     if (Ty->isPointerTy() || Ty->isFloatingPointTy() || Ty->isVectorTy())
       ArgTys = {Ty};


### PR DESCRIPTION
When I build swift code as debuggable, I got the following error:

```
error: couldn't allocate input reg for constraint 'r'
```

This means we can't use `InlineAsm` with registers because WASM doesn't have registers.
Swift uses `InlineAsm` to extend lifetime of variable for debugging. So I changed to avoid to use it.

After this change, we can build swift standard library as debuggable via `./utils/build-script --debug`.

## References
- https://gcc.gnu.org/onlinedocs/gcc/Simple-Constraints.html#Simple-Constraints