### PR TITLE
[WASM] Set LIBC_INCLUDE_DIRECTORY for WASM to build SwiftGlibc properly

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -324,6 +324,8 @@ macro(configure_sdk_unix name architectures)
         set(SWIFT_SDK_WASM_ARCH_wasm32_PATH "${SWIFT_WASM_WASI_SDK_PATH}/share/sysroot")
         # fixme: Wasi is wasm32-unknown-wasi-musl. This LLVM doesn't have it yet.
         set(SWIFT_SDK_WASM_ARCH_wasm32_TRIPLE "wasm32-unknown-unknown-wasm")
+        set(SWIFT_SDK_WASM_ARCH_wasm32_LIBC_INCLUDE_DIRECTORY "${SWIFT_WASM_WASI_SDK_PATH}/share/sysroot/include" CACHE STRING "Path to C library headers")
+        set(SWIFT_SDK_WASM_ARCH_wasm32_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY "${SWIFT_WASM_WASI_SDK_PATH}/sysroot/include" CACHE STRING "Path to C library architecture headers")
       else()
         message(FATAL_ERROR "unknown Unix OS: ${prefix}")
       endif()


### PR DESCRIPTION
<!-- What's in this pull request? -->

`LIBC_INCLUDE_DIRECTORY` is used to generate `glibc.modulemap`.
Currently the directory is set `/usr/include` but it's system header path and we should use `wasi-sdk` version.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
