### PR TITLE
Update WASI SDK, create installable package on macOS

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,5 +1,7 @@
 #/bin/bash
 
+export sourcedir=$PWD/..
+
 ./utils/build-script --release --wasm --verbose \
   --skip-build-benchmarks \
   --extra-cmake-options=" \

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,5 +1,7 @@
 #/bin/bash
 
+export sourcedir=$PWD/..
+
 ./utils/build-script --release --wasm --verbose \
   --skip-build-benchmarks \
   --extra-cmake-options=" \

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -22,4 +22,8 @@
   --wasm-icu-i18n-include "$sourcedir/icu_out/include" \
   --wasm-icu-uc "$sourcedir/icu_out/lib" \
   --wasm-icu-uc-include "$sourcedir/icu_out/include" \
-  --wasm-wasi-sdk "$sourcedir/wasi-sdk"
+  --wasm-wasi-sdk "$sourcedir/wasi-sdk" \
+  --install-swift \
+  --install-prefix="/opt/swiftwasm-sdk" \
+  --install-destdir="$sourcedir/install" \
+  --installable-package="$sourcedir/swiftwasm-mac.tar.gz"

--- a/ci-linux.sh
+++ b/ci-linux.sh
@@ -22,9 +22,10 @@ sudo ./install_cmake.sh --skip-license --prefix=/opt/cmake
 sudo ln -sf /opt/cmake/bin/* /usr/local/bin
 cmake --version
 
-wget -O wasi-sdk.tar.gz https://github.com/swiftwasm/wasi-sdk/releases/download/20190421.6/wasi-sdk-3.19gefb17cb478f9.m-linux.tar.gz
+wget -O wasi-sdk.tar.gz https://github.com/swiftwasm/wasi-sdk/releases/download/20191022.1/wasi-sdk-4.39g3025a5f47c04-linux.tar.gz
 tar xfz wasi-sdk.tar.gz
-mv wasi-sdk-3.19gefb17cb478f9+m/opt/wasi-sdk ./wasi-sdk
+mv wasi-sdk-4.39g3025a5f47c04 ./wasi-sdk
+mv wasi-sdk/share/wasi-sysroot wasi-sdk/share/sysroot
 
 wget -O icu.tar.xz "https://github.com/swiftwasm/icu4c-wasi/releases/download/20190421.3/icu4c-wasi.tar.xz"
 tar xf icu.tar.xz

--- a/ci-mac.sh
+++ b/ci-mac.sh
@@ -6,9 +6,9 @@ export current_sha=`git rev-parse HEAD`
 git checkout $current_sha
 export sourcedir=$PWD/..
 cd $sourcedir
-wget -O wasi-sdk.tar.gz https://github.com/swiftwasm/wasi-sdk/releases/download/20190421.6/wasi-sdk-3.19gefb17cb478f9.m-linux.tar.gz
+wget -O wasi-sdk.tar.gz https://github.com/swiftwasm/wasi-sdk/releases/download/20191022.1/wasi-sdk-4.39g3025a5f47c04-linux.tar.gz
 tar xfz wasi-sdk.tar.gz
-mv wasi-sdk-3.19gefb17cb478f9+m/opt/wasi-sdk ./wasi-sdk
+mv wasi-sdk-4.39g3025a5f47c04 ./wasi-sdk
 # Link sysroot/usr/include to sysroot/include because Darwin sysroot doesn't 
 # find header files in sysroot/include but sysroot/usr/include
 mkdir wasi-sdk/share/sysroot/usr/

--- a/ci-mac.sh
+++ b/ci-mac.sh
@@ -9,6 +9,7 @@ cd $sourcedir
 wget -O wasi-sdk.tar.gz https://github.com/swiftwasm/wasi-sdk/releases/download/20191022.1/wasi-sdk-4.39g3025a5f47c04-linux.tar.gz
 tar xfz wasi-sdk.tar.gz
 mv wasi-sdk-4.39g3025a5f47c04 ./wasi-sdk
+mv wasi-sdk/share/wasi-sysroot wasi-sdk/share/sysroot
 # Link sysroot/usr/include to sysroot/include because Darwin sysroot doesn't 
 # find header files in sysroot/include but sysroot/usr/include
 mkdir wasi-sdk/share/sysroot/usr/

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -20,7 +20,7 @@ import MSVCRT
 #endif
 
 public func _stdlib_mkstemps(_ template: inout String, _ suffixlen: CInt) -> CInt {
-#if os(Android) || os(Haiku) || os(Windows)
+#if os(Android) || os(Haiku) || os(Windows) || os(Wasm)
   preconditionFailure("mkstemps doesn't work on your platform")
 #else
   var utf8CStr = template.utf8CString

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -353,12 +353,14 @@ module SwiftGlibc [system] {
       header "${GLIBC_INCLUDE_PATH}/libgen.h"
       export *
     }
+% if CMAKE_SDK != "WASM":
     module net {
       module if {
         header "${GLIBC_INCLUDE_PATH}/net/if.h"
         export *
       }
     }
+% end
     module netinet {
       module in {
         header "${GLIBC_INCLUDE_PATH}/netinet/in.h"

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -519,10 +519,12 @@ module SwiftGlibc [system] {
       export *
     }
 % end
+% if CMAKE_SDK != "WASM":
     module termios {
       header "${GLIBC_INCLUDE_PATH}/termios.h"
       export *
     }
+% end
     module unistd {
       header "${GLIBC_INCLUDE_PATH}/unistd.h"
       export *


### PR DESCRIPTION
New WASI SDK package should contain a new version of the linker. Also, the script should now create an installable package on macOS so that one could create a full SwiftWasm package later after the build.