### PR TITLE
Make SymbolLookup.swift compilable for wasm

### DIFF
--- a/stdlib/private/StdlibUnittest/SymbolLookup.swift
+++ b/stdlib/private/StdlibUnittest/SymbolLookup.swift
@@ -12,7 +12,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(Wasm)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
@@ -23,7 +23,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
-#elseif os(Linux)
+#elseif os(Linux) || os(Wasm)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)
 #elseif os(Android)
   #if arch(arm) || arch(i386)
@@ -43,6 +43,8 @@ public func pointerToSwiftCoreSymbol(name: String) -> UnsafeMutableRawPointer? {
 #if os(Windows)
   return unsafeBitCast(GetProcAddress(hStdlibCore, name),
                        to: UnsafeMutableRawPointer?.self)
+#elseif os(Wasm)
+  fatalError("\(#function) is not supported on WebAssembly")
 #else
   return dlsym(RTLD_DEFAULT, name)
 #endif


### PR DESCRIPTION
`SymbolLookup.swift` was added recently, which broke our builds after rebasing on top of Apple's `master`. Using anything from this file wouldn't make sense on WebAssembly. It looks there are no codepaths that would call it on that platform, but there are still references to it around, so it has to be at least compilable.