### PR TITLE
[WASM] Link start/stop symbol weakly

### DIFF
--- a/stdlib/public/runtime/SwiftRT-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-WASM.cpp
@@ -14,14 +14,10 @@
 
 #include <cstddef>
 
-// Create empty sections to ensure that the start/stop symbols are synthesized
-// by the linker.  Otherwise, we may end up with undefined symbol references as
-// the linker table section was never constructed.
-
+// Link start/stop symbols weakly to link them if they aren't synthesized by the linker. 
 #define DECLARE_SWIFT_SECTION(name)                                                             \
-  __attribute__((__used__,__section__(#name),__aligned__(1))) const char __dummy_##name = 0x00; \
-  __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __start_##name;    \
-  __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __stop_##name;
+  __attribute__((__visibility__("hidden"),__aligned__(1),weak)) extern const char __start_##name;    \
+  __attribute__((__visibility__("hidden"),__aligned__(1),weak)) extern const char __stop_##name;
 
 extern "C" {
 DECLARE_SWIFT_SECTION(swift5_protocols)


### PR DESCRIPTION
This PR fixed my runtime implmentation in SwiftRT.
I've inserted dummy `char` data in each metadata sections to ensure that all start/stop symbols are generated in https://github.com/swiftwasm/swift/pull/11. But of cource this dummy data can be inserted anywhere in the section, so metadata sections were broken by this 1 byte.

I changed to link these start/stop symbols weakly. Non-generated start/stop variables get to be uninitialized. So `stop-start` results 0 length, and runtime library can avoid to load empty section.


After this and https://github.com/swiftwasm/swift/pull/6 are merged, `print("Hello")` will work again! 🎉 