### PR TITLE
Fix paths in packaging scripts

### DIFF
--- a/utils/webassembly/copy-shared-files.sh
+++ b/utils/webassembly/copy-shared-files.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 cp -r ../sdkroot/* compiler/
-cp ../linux/compiler/opt/swiftwasm-sdk/lib/swift/wasm/wasm32/glibc.modulemap compiler/extra_utils
+cp ../linux/compiler/opt/swiftwasm-sdk/lib/swift/wasi/wasm32/glibc.modulemap compiler/extra_utils

--- a/utils/webassembly/macos/unpack-prebuilts.sh
+++ b/utils/webassembly/macos/unpack-prebuilts.sh
@@ -24,7 +24,7 @@ mv compiler/wasi-sdk/share/wasi-sysroot compiler/wasi-sdk/share/sysroot
 rm -r compiler/wasi-sdk/bin
 mkdir compiler/wasi-sdk/bin
 cp tmpdir/clang+llvm-*-x86_64-darwin-apple/bin/wasm-ld compiler/wasi-sdk/bin
-cp -a tmpdir/opt/swiftwasm-sdk/lib/swift/wasm compiler/opt/swiftwasm-sdk/lib/swift/wasm
+cp -a tmpdir/opt/swiftwasm-sdk/lib/swift/wasi compiler/opt/swiftwasm-sdk/lib/swift/wasi
 cp -a tmpdir/opt/swiftwasm-sdk/lib/swift_static compiler/opt/swiftwasm-sdk/lib/swift_static
 # ok, finally copy over the shared files
 ../copy-shared-files.sh || true


### PR DESCRIPTION
`wasm` was replaced with `wasi` in the platform triple, the packaging scripts are now updated accordingly.