### PR TITLE
Bump macOS to 10.15 in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
   macos_build:
     timeout-minutes: 0
-    runs-on: macOS-10.14
+    runs-on: macOS-10.15
 
     steps:
       - uses: actions/checkout@v1
@@ -100,7 +100,7 @@ jobs:
 
   macos_smoke_test:
     name: Compile hello.swift on macOS
-    runs-on: macOS-10.14
+    runs-on: macOS-10.15
     needs: package
     steps:
       - name: Download SwiftWasm macOS package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
   macos_build:
     timeout-minutes: 0
-    runs-on: macOS-10.15
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -100,7 +100,7 @@ jobs:
 
   macos_smoke_test:
     name: Compile hello.swift on macOS
-    runs-on: macOS-10.15
+    runs-on: macos-latest
     needs: package
     steps:
       - name: Download SwiftWasm macOS package


### PR DESCRIPTION
Potentially this should enable switching to Xcode 11.2.1 and even 11.3 when the latter is available.