### PR TITLE
Fix sil-func-extractor and driver

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -346,7 +346,12 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
   ArgStringList Arguments;
 
   // Configure the toolchain.
-  const char *AR = "ar";
+  const char *AR;
+  if (getTriple().isOSBinFormatWasm()) {
+    AR = "llvm-ar";
+  } else {
+    AR = "ar";
+  }
   Arguments.push_back("crs");
 
   Arguments.push_back(

--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=wasi
 // In Android jmp_buf is int[16], which doesn't convert to &Int (SR-9136)
 // XFAIL: OS=linux-androideabi
 // XFAIL: OS=linux-android

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1226,7 +1226,7 @@ elif run_os == 'wasi':
 
     config.target_object_format = "wasm"
     config.target_shared_library_prefix = 'lib'
-    config.target_shared_library_suffix = ".so"
+    config.target_shared_library_suffix = ".a"
     config.target_sdk_name = "wasi"
     config.target_runtime = "native"
 
@@ -1246,7 +1246,7 @@ elif run_os == 'wasi':
     config.target_build_swift_dylib = (
         "%s -parse-as-library -emit-library -o '\\1'"
         % (config.target_build_swift))
-    config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
+    config.target_add_rpath = ''
     config.target_swift_frontend = (
         '%s -frontend -target %s %s %s %s %s '
         % (config.swift, config.variant_triple, resource_dir_opt, mcp_opt,

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1230,6 +1230,26 @@ elif run_os == 'wasi':
     config.target_sdk_name = "wasi"
     config.target_runtime = "native"
 
+    # Exclude test cases that use objc-interop because clang doesn't support it
+    # with WebAssembly binary file yet.
+    testfiles = glob.glob(os.path.join(config.test_source_root, "**", "*.swift"))
+
+    def use_objc_interop(path):
+      with open(path) as f:
+        return '-enable-objc-interop' in f.read()
+
+    import fnmatch
+    def objc_interop_enabled_filenames(path, filename_pat):
+      matches = []
+      for root, dirnames, filenames in os.walk(path):
+        for filename in fnmatch.filter(filenames, filename_pat):
+          filepath = os.path.join(root, filename)
+          if not use_objc_interop(filepath): continue
+          matches.append(filename)
+      return matches
+
+    config.excludes += objc_interop_enabled_filenames(config.test_source_root, "*.swift")
+
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
     config.target_build_swift = ' '.join([

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -249,6 +249,8 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().DisableAvailabilityChecking = true;
   Invocation.getLangOptions().EnableAccessControl = false;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
+  if (Invocation.getLangOptions().Target.isOSBinFormatWasm())
+    Invocation.getLangOptions().EnableObjCInterop = false;
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =


### PR DESCRIPTION
- Use `llvm-ar` instead of `ar` because `ar` doesn't support latest webassembly archiving
- Disable objc-interop of sil-func-extractor to pass some test cases
  - `clang` doesn't support Objective-C using wasm obejct file format
  - Crashed [here](https://github.com/apple/llvm-project/blob/c3e5ae3fdebb67d936aeec2b04b7d2b6a784f69e/clang/lib/CodeGen/CGObjCMac.cpp#L5065-L5084)
  - And there is no plan to support it
- Exclude test cases which use `-enable-objc-interop` flag due to same reason.