### PR TITLE
Fix unit tests part1

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -1449,7 +1449,12 @@ public func runAllTests() {
   if _isChildProcess {
     _childProcess()
   } else {
+    #if os(WASI)
+    // WASI doesn't support child process
+    var runTestsInProcess: Bool = true
+    #else
     var runTestsInProcess: Bool = false
+    #endif
     var filter: String?
     var args = [String]()
     var i = 0

--- a/stdlib/public/WASI/CMakeLists.txt
+++ b/stdlib/public/WASI/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_swift_target_library(swiftWasiPthread STATIC IS_STDLIB
   Pthread.cpp
+  TARGET_SDKS WASI
   INSTALL_IN_COMPONENT stdlib)

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: linux, windows
+// XFAIL: linux, windows, wasm
 
 import simd
 


### PR DESCRIPTION
This is a sample PR for https://github.com/swiftwasm/swift/issues/29
- https://github.com/swiftwasm/swift/pull/31/commits/7a3f27e51188b420e564ed29bb29f13465f2d53f https://github.com/swiftwasm/swift/pull/31/commits/629b8f2df26a66b9d03698361005c192b0165210 Disable mmap and simd related test case because wasm doesn't have enough api to implement it.
- https://github.com/swiftwasm/swift/pull/31/commits/ed5f4fc7609a9c126b9fba630eff2218219d966d Implement `CommandLine.arguments` to run stdlib test cases using `StdlibUnittest` framework.
- https://github.com/swiftwasm/swift/pull/31/commits/552d3149bb4ea69d79421141e6a0d878721303a8 Run StdlibUnittest test cases in process instead of spawning child processes.
