### PR TITLE
Setup upstream tracking

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,6 @@
+version: "1"
+rules:
+  - base: swiftwasm
+    upstream: apple:master
+    mergeMethod: merge
+label: ":arrow_heading_down: Upstream Tracking"


### PR DESCRIPTION
Configure `pull` which create merge request for every upstream commit like [this](https://github.com/kateinoigakukun/swiftwasm/pull/52)

This triggers CI for every commit, so this makes it clear which upstream commit breaks our changes.

In practice, I faced some upstream commits broke our change, but I could make [patch](https://github.com/apple/swift/pull/29499) easily 😄 

<img src=https://user-images.githubusercontent.com/11702759/73350982-6f3ba780-42d1-11ea-8d93-aa5c67a493d1.jpg width=50%>


Before merge this, please install https://github.com/apps/pull in this repository 🙏 