### PR TITLE
Update upstream tracking strategy via own master branch

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,6 +1,9 @@
 version: "1"
 rules:
   - base: swiftwasm
-    upstream: apple:master
+    upstream: master
     mergeMethod: merge
+  - base: master
+    upstream: apple:master
+    mergeMethod: hardreset
 label: ":arrow_heading_down: Upstream Tracking"

--- a/utils/webassembly/ci-linux.sh
+++ b/utils/webassembly/ci-linux.sh
@@ -34,8 +34,8 @@ sudo ./install_cmake.sh --skip-license --prefix=/opt/cmake
 sudo ln -sf /opt/cmake/bin/* /usr/local/bin
 cmake --version
 
-wget -O dist-wasi-sdk.tgz https://github.com/swiftwasm/wasi-sdk/suites/370986556/artifacts/809002
-unzip dist-wasi-sdk.tgz -d .
+wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.1.0-swiftwasm/dist-ubuntu-latest.tgz.zip"
+unzip dist-wasi-sdk.tgz.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -linux.tar.gz)
 tar xfz $WASI_SDK_TAR_PATH

--- a/utils/webassembly/ci-mac.sh
+++ b/utils/webassembly/ci-mac.sh
@@ -23,8 +23,8 @@ sudo ln -sf /opt/wasmtime/* /usr/local/bin
 
 cd $SOURCE_PATH
 
-wget -O dist-wasi-sdk.tgz https://github.com/swiftwasm/wasi-sdk/suites/370986556/artifacts/809001
-unzip dist-wasi-sdk.tgz -d .
+wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.1.0-swiftwasm/dist-macos-latest.tgz.zip"
+unzip dist-wasi-sdk.tgz.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -macos.tar.gz)
 tar xfz $WASI_SDK_TAR_PATH


### PR DESCRIPTION
Changed to create merge PR from it's own master branch which is
automatically synced with apple:master.
Creating merge PR from apple:master sends CI failure email to apple
members, so we need to change tracking strategy.

New Tracking steps:

1. sync master branch from apple:master
apple:master -> swiftwasm:master

2. create merge PR from swiftwasm:master
swiftwasm:master -> swiftwasm:swiftwasm
