### PR TITLE
Add ifdef to ThreadBarriers to fix master builds

### DIFF
--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -87,6 +87,19 @@ public func _stdlib_thread_barrier_init(
   return 0
 }
 
+#if !os(Windows) && !os(WASI)
+private func _stdlib_thread_barrier_mutex_and_cond_init(_ barrier: UnsafeMutablePointer<_stdlib_thread_barrier_t>) -> CInt {
+  guard pthread_mutex_init(barrier.pointee.mutex!, nil) == 0 else {
+    return -1
+  }
+  guard pthread_cond_init(barrier.pointee.cond!, nil) == 0 else {
+    pthread_mutex_destroy(barrier.pointee.mutex!)
+    return -1
+  }
+  return 0
+}
+#endif
+
 public func _stdlib_thread_barrier_destroy(
   _ barrier: UnsafeMutablePointer<_stdlib_thread_barrier_t>
 ) -> CInt {


### PR DESCRIPTION
This adds an `os(WASI)` ifdef to the new `_stdlib_thread_barrier_mutex_and_cond_init` function added to `ThreadBarriers.swift` on `master`. Hope this will make #39 pass.