### PR TITLE
[WASM] Update WASI SDK to 0.2.0

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1367,6 +1367,10 @@ elif run_os == 'wasi':
     config.target_sil_opt = (
         '%s -target %s %s %s %s' %
         (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
+    config.target_swift_symbolgraph_extract = ' '.join([
+        config.swift_symbolgraph_extract,
+        '-target', config.variant_triple,
+        mcp_opt])
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, resource_dir_opt,

--- a/utils/webassembly/ci-linux.sh
+++ b/utils/webassembly/ci-linux.sh
@@ -34,7 +34,7 @@ sudo ./install_cmake.sh --skip-license --prefix=/opt/cmake
 sudo ln -sf /opt/cmake/bin/* /usr/local/bin
 cmake --version
 
-wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.1.0-swiftwasm/dist-ubuntu-latest.tgz.zip"
+wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-ubuntu-latest.tgz.zip"
 unzip dist-wasi-sdk.tgz.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -linux.tar.gz)

--- a/utils/webassembly/ci-mac.sh
+++ b/utils/webassembly/ci-mac.sh
@@ -23,7 +23,7 @@ sudo ln -sf /opt/wasmtime/* /usr/local/bin
 
 cd $SOURCE_PATH
 
-wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.1.0-swiftwasm/dist-macos-latest.tgz.zip"
+wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
 unzip dist-wasi-sdk.tgz.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -macos.tar.gz)


### PR DESCRIPTION
When using wasm-ld in wasi-sdk 0.1.0-swiftwasm, some test cases in swift are failed with "failed to demangle witness for associated type 'Iterator' in conformance 'Swift.UInt64.Words: Sequence' from mangled name '$e'" message.

This message means that runtime library fails to look up for protocol conformance from swift5_protocol_conformances section. In WebAssembly binary, these protocol conformances data are stored in data segments in each object files and link them into one segment by wasm-ld.

Swift runtime library uses special __start and __stop symbols to point where the metadata section is located. These special symbols are emitted by linker wasm-ld. But wasm-ld in wasi-sdk 0.1.0 emitited them for each data segments without combining them by their name. This causes the
crash if an user code has a protocol conformance because __start and __stop symbols point only the user defined protocol conformance segment.

The wasm-ld bug has been fixed by this patch https://reviews.llvm.org/D64148
