### PR TITLE
Avoid installing deprecated Python 2 from Homebrew

### DIFF
--- a/utils/webassembly/ci-linux.sh
+++ b/utils/webassembly/ci-linux.sh
@@ -48,6 +48,5 @@ ln -s wasm32-wasi wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi-unknown
 wget -O icu.tar.xz "https://github.com/swiftwasm/icu4c-wasi/releases/download/20190421.3/icu4c-wasi.tar.xz"
 tar xf icu.tar.xz
 
-$BUILD_SCRIPT --release --debug-swift-stdlib --verbose
 # Run test but ignore failure temporarily
 $BUILD_SCRIPT --release --debug-swift-stdlib --verbose -t || true

--- a/utils/webassembly/ci-linux.sh
+++ b/utils/webassembly/ci-linux.sh
@@ -48,5 +48,6 @@ ln -s wasm32-wasi wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi-unknown
 wget -O icu.tar.xz "https://github.com/swiftwasm/icu4c-wasi/releases/download/20190421.3/icu4c-wasi.tar.xz"
 tar xf icu.tar.xz
 
+$BUILD_SCRIPT --release --debug-swift-stdlib --verbose
 # Run test but ignore failure temporarily
 $BUILD_SCRIPT --release --debug-swift-stdlib --verbose -t || true

--- a/utils/webassembly/ci-mac.sh
+++ b/utils/webassembly/ci-mac.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+brew uninstall python@2 || true
 brew install cmake ninja llvm
 
 SOURCE_PATH="$( cd "$(dirname $0)/../../.." && pwd  )" 

--- a/utils/webassembly/ci-mac.sh
+++ b/utils/webassembly/ci-mac.sh
@@ -39,6 +39,5 @@ ln -s wasm32-wasi wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi-unknown
 wget -O icu.tar.xz "https://github.com/swiftwasm/icu4c-wasi/releases/download/20190421.3/icu4c-wasi.tar.xz"
 tar xf icu.tar.xz
 
-$BUILD_SCRIPT --release --debug-swift-stdlib --verbose
 # Run test but ignore failure temporarily
 $BUILD_SCRIPT --release --debug-swift-stdlib --verbose -t || true

--- a/utils/webassembly/ci-mac.sh
+++ b/utils/webassembly/ci-mac.sh
@@ -2,10 +2,7 @@
 
 set -ex
 
-brew install cmake ninja llvm python@2
-
-# Install six for python3 migration
-pip2 install six
+brew install cmake ninja llvm
 
 SOURCE_PATH="$( cd "$(dirname $0)/../../.." && pwd  )" 
 SWIFT_PATH=$SOURCE_PATH/swift

--- a/utils/webassembly/ci-mac.sh
+++ b/utils/webassembly/ci-mac.sh
@@ -39,5 +39,6 @@ ln -s wasm32-wasi wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi-unknown
 wget -O icu.tar.xz "https://github.com/swiftwasm/icu4c-wasi/releases/download/20190421.3/icu4c-wasi.tar.xz"
 tar xf icu.tar.xz
 
+$BUILD_SCRIPT --release --debug-swift-stdlib --verbose
 # Run test but ignore failure temporarily
 $BUILD_SCRIPT --release --debug-swift-stdlib --verbose -t || true


### PR DESCRIPTION
`brew install python@2` now fails for me locally due to Homebrew/homebrew-core#49796, not sure how it still runs fine on CI, probably due to caches not being cleaned up as frequently.

I hope relying on system-installed Python should work fine.