### PR TITLE
[WASM] Always build static library for WASM

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1432,13 +1432,18 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerOutputType = file_types::TY_Object;
       break;
 
-    case options::OPT_emit_library:
-      OI.LinkAction = Args.hasArg(options::OPT_static) ?
-                      LinkKind::StaticLibrary :
-                      LinkKind::DynamicLibrary;
+    case options::OPT_emit_library: {
+      // WebAssembly only support static library
+      if (TC.getTriple().isOSBinFormatWasm()) {
+        OI.LinkAction = LinkKind::StaticLibrary;
+      } else {
+        OI.LinkAction = Args.hasArg(options::OPT_static) ?
+                        LinkKind::StaticLibrary :
+                        LinkKind::DynamicLibrary;
+      }
       OI.CompilerOutputType = file_types::TY_Object;
       break;
-
+    }
     case options::OPT_static:
       break;
 


### PR DESCRIPTION
Now, wasm doesn't support dynamic linking, so emit a library as static for default.