### PR TITLE
[WASM] Disable unsupported test suite on WASM

### DIFF
--- a/test/AutolinkExtract/empty.swift
+++ b/test/AutolinkExtract/empty.swift
@@ -5,3 +5,4 @@
 
 // CHECK-elf: -lswiftCore
 // CHECK-coff: -lswiftCore
+// CHECK-wasm: -lswiftCore

--- a/test/AutolinkExtract/empty_archive.swift
+++ b/test/AutolinkExtract/empty_archive.swift
@@ -7,3 +7,4 @@
 
 // CHECK-elf: -lswiftCore
 // CHECK-coff: -lswiftCore
+// CHECK-wasm: -lswiftCore

--- a/test/AutolinkExtract/import.swift
+++ b/test/AutolinkExtract/import.swift
@@ -11,4 +11,7 @@
 // CHECK-coff-DAG: -lswiftCore
 // CHECK-coff-DAG: -lempty
 
+// CHECK-wasm-DAG: -lswiftCore
+// CHECK-wasm-DAG: -lempty
+
 import empty

--- a/test/ClangImporter/clang_builtins.swift
+++ b/test/ClangImporter/clang_builtins.swift
@@ -2,7 +2,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   import Glibc
 #elseif os(Windows)
   import MSVCRT

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -2,7 +2,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   import Glibc
 #elseif os(Windows)
   import MSVCRT

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -7,6 +7,7 @@
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,indirect-calls %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_INDIRECT_CALLS
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,8bit-counters %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_8BIT_COUNTERS
 // RUN: %target-swift-frontend -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
+// UNSUPPORTED: wasm
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin

--- a/test/Interpreter/dynamicReplacement_property_observer.swift
+++ b/test/Interpreter/dynamicReplacement_property_observer.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
+// UNSUPPORTED: wasm
 
 @_private(sourceFile: "dynamic_replacement_property_observer_orig.swift") import TestDidWillSet
 

--- a/test/Interpreter/dynamic_replacement.swift
+++ b/test/Interpreter/dynamic_replacement.swift
@@ -48,6 +48,7 @@
 
 
 // REQUIRES: executable_test
+// UNSUPPORTED: wasm
 
 import Module1
 

--- a/test/Interpreter/dynamic_replacement_chaining.swift
+++ b/test/Interpreter/dynamic_replacement_chaining.swift
@@ -20,6 +20,7 @@
 
 // This test flips the chaining flag.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
+// UNSUPPORTED: wasm
 
 import A
 

--- a/test/Interpreter/dynamic_replacement_without_previous_calls.swift
+++ b/test/Interpreter/dynamic_replacement_without_previous_calls.swift
@@ -6,6 +6,7 @@
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // REQUIRES: executable_test
+// UNSUPPORTED: wasm
 
 import Module1
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1320,8 +1320,6 @@ elif run_os == 'wasi':
 
     # Exclude test cases that use objc-interop because clang doesn't support it
     # with WebAssembly binary file yet.
-    testfiles = glob.glob(os.path.join(config.test_source_root, "**", "*.swift"))
-
     def use_objc_interop(path):
       with open(path) as f:
         return '-enable-objc-interop' in f.read()
@@ -1329,18 +1327,16 @@ elif run_os == 'wasi':
       with open(path) as f:
         return 'lldb-moduleimport-test' in f.read()
 
-    import fnmatch
-    def disabled_filenames(path, filename_pat):
+    def disabled_filenames(path):
       matches = []
       for root, dirnames, filenames in os.walk(path):
-        for filename in fnmatch.filter(filenames, filename_pat):
+        for filename in filenames:
           filepath = os.path.join(root, filename)
-          if not use_objc_interop(filepath): continue
-          if not lldb_related_test(filepath): continue
-          matches.append(filename)
+          if use_objc_interop(filepath) or lldb_related_test(filepath):
+            matches.append(os.path.basename(filepath))
       return matches
 
-    config.excludes += disabled_filenames(config.test_source_root, "*.swift")
+    config.excludes += disabled_filenames(config.test_source_root)
 
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
@@ -1369,7 +1365,7 @@ elif run_os == 'wasi':
            config.swift_test_options, config.swift_frontend_test_options)
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = 'wasmtime'
+    config.target_run = 'wasmtime --'
     if 'interpret' in lit_config.params:
         use_interpreter_for_simple_runs()
     config.target_sil_opt = (

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -369,6 +369,7 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)") {
   }
 }
 
+#if !os(WASI)
 UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -378,6 +379,7 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
   expectCrashLater()
   _blackHole(UInt8(ascii: us))
 }
+#endif
 
 UnicodeScalarTests.test("UInt32(_: UnicodeScalar),UInt64(_: UnicodeScalar)") {
   for us in baseScalars {

--- a/test/stdlib/CharacterTraps.swift
+++ b/test/stdlib/CharacterTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/DictionaryTraps.swift
+++ b/test/stdlib/DictionaryTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/FloatingPointIR.swift
+++ b/test/stdlib/FloatingPointIR.swift
@@ -49,3 +49,6 @@ func testConstantFoldFloatLiterals() {
 
 // s390x: call swiftcc void @"$s15FloatingPointIR13acceptFloat32yySfF{{.*}}"(float 1.000000e+00)
 // s390x: call swiftcc void @"$s15FloatingPointIR13acceptFloat64yySdF{{.*}}"(double 1.000000e+00)
+
+// wasm32: call swiftcc void @"$s15FloatingPointIR13acceptFloat32yySfF{{.*}}"(float 1.000000e+00)
+// wasm32: call swiftcc void @"$s15FloatingPointIR13acceptFloat64yySdF{{.*}}"(double 1.000000e+00)

--- a/test/stdlib/IntervalTraps.swift
+++ b/test/stdlib/IntervalTraps.swift
@@ -18,6 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -422,6 +422,7 @@ keyPath.test("optional force-unwrapping") {
   expectTrue(value.questionableCanary === newCanary)
 }
 
+#if !os(WASI)
 keyPath.test("optional force-unwrapping trap") {
   let origin_x = \TestOptional.origin!.x
   var value = TestOptional(origin: nil)
@@ -429,6 +430,7 @@ keyPath.test("optional force-unwrapping trap") {
   expectCrashLater()
   _ = value[keyPath: origin_x]
 }
+#endif
 
 struct TestOptional2 {
   var optional: TestOptional?

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -107,6 +107,7 @@ tests.test("${Self}/success") {
   % end
 }
 
+#if !os(WASI)
 tests.test("${Self}/radixTooLow") {
   ${Self}("0", radix: 2)
   expectCrashLater()
@@ -119,6 +120,7 @@ tests.test("${Self}/radixTooHigh") {
   expectCrashLater()
   let y = ${Self}("0", radix: maxRadix + 1)
 }
+#endif
 
 % end
 

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -338,6 +338,7 @@ OptionalTests.test("Casting Optional") {
   expectTrue(anyToAnyIsOptional(Optional<(String, String)>.none, Bool.self))
 }
 
+#if !os(WASI)
 OptionalTests.test("Casting Optional Traps") {
   let nx: C? = nil
   expectCrash { _blackHole(anyToAny(nx, Int.self)) }
@@ -346,6 +347,7 @@ OptionalTests.test("Casting Optional Any Traps") {
   let nx: X? = X()
   expectCrash { _blackHole(anyToAny(nx as Any, Optional<Int>.self)) }
 }
+#endif
 
 class TestNoString {}
 class TestString : CustomStringConvertible, CustomDebugStringConvertible {
@@ -407,6 +409,7 @@ OptionalTests.test("unsafelyUnwrapped") {
   expectEqual(3, nonEmpty.unsafelyUnwrapped)
 }
 
+#if !os(WASI)
 OptionalTests.test("unsafelyUnwrapped nil")
   .xfail(.custom(
     { !_isDebugAssertConfiguration() },
@@ -416,5 +419,6 @@ OptionalTests.test("unsafelyUnwrapped nil")
   expectCrashLater()
   _blackHole(empty.unsafelyUnwrapped)
 }
+#endif
 
 runAllTests()

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -10,6 +10,7 @@
 // RUN: %target-run %t/Assert_Release
 // RUN: %target-run %t/Assert_Unchecked
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -1,11 +1,12 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #else
 #error("Unsupported platform")

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -12,7 +12,7 @@
 import StdlibUnittest
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   import Glibc
 #elseif os(Windows)
   import MSVCRT

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -18,6 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 
 import StdlibUnittest

--- a/test/stdlib/Repeat.swift
+++ b/test/stdlib/Repeat.swift
@@ -23,11 +23,13 @@ RepeatTests.test("associated-types") {
       indicesType: CountableRange<Int>.self)
 }
 
+#if !os(WASI)
 RepeatTests.test("out-of-bounds") {
   let sequence = repeatElement(0, count: 1)
   expectCrashLater()
   _ = sequence[sequence.count]
 }
+#endif
 
 runAllTests()
 

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -591,6 +591,8 @@ Runtime.test("Struct layout with reference storage types") {
   print(malkovich)
 }
 
+// WebAssembly/WASI doesn't support dynamic symbol lookup
+#if !os(WASI)
 Runtime.test("SwiftError layout constants for LLDB") {
   let offsetof_SwiftError_typeMetadata = pointerToSwiftCoreSymbol(name: "_swift_lldb_offsetof_SwiftError_typeMetadata")!
   let sizeof_SwiftError = pointerToSwiftCoreSymbol(name: "_swift_lldb_sizeof_SwiftError")!
@@ -610,6 +612,7 @@ Runtime.test("SwiftError layout constants for LLDB") {
   _UnimplementedError()
 #endif
 }
+#endif
 
 var Reflection = TestSuite("Reflection")
 

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/StaticString.swift
+++ b/test/stdlib/StaticString.swift
@@ -69,6 +69,7 @@ StaticStringTestSuite.test("PointerRepresentation/NonASCII") {
   expectDebugPrinted("\"абв\"", str)
 }
 
+#if !os(WASI)
 StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -81,6 +82,7 @@ StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
   expectCrashLater()
   strOpaque.unicodeScalar
 }
+#endif
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/ASCII") {
   // The type checker does not call the UnicodeScalar initializer even if
@@ -119,6 +121,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/NonASCII") {
   expectDebugPrinted("\"Ы\"", str)
 }
 
+#if !os(WASI)
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -144,6 +147,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8CodeUnitCount")
   expectCrashLater()
   strOpaque.utf8CodeUnitCount
 }
+#endif
 
 runAllTests()
 

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -304,6 +304,7 @@ func checkPtr(
   }
 }
 
+#if !os(WASI)
 UnsafeMutablePointerTestSuite.test("moveAssign:from:") {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   check(Check.Disjoint)
@@ -322,6 +323,7 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right") {
     check(Check.RightOverlap)
   }
 }
+#endif
 
 UnsafeMutablePointerTestSuite.test("assign:from:") {
   let check = checkPtr(UnsafeMutablePointer.assign, true)
@@ -337,6 +339,7 @@ UnsafeMutablePointerTestSuite.test("moveInitialize:from:") {
   check(Check.RightOverlap)
 }
 
+#if !os(WASI)
 UnsafeMutablePointerTestSuite.test("initialize:from:") {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   check(Check.Disjoint)
@@ -355,6 +358,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from:.Right") {
     check(Check.RightOverlap)
   }
 }
+#endif
 
 UnsafeMutablePointerTestSuite.test("initialize:from:/immutable") {
   var ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 3)
@@ -400,7 +404,7 @@ ${SelfName}TestSuite.test("customMirror") {
   let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   let mirror = ptr.customMirror
   expectEqual(1, mirror.children.count)
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
   expectEqual("18446744071562067968", String(describing: mirror.children.first!.1))
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   expectEqual("9223372036854775808", String(describing: mirror.children.first!.1))
@@ -415,7 +419,7 @@ ${SelfName}TestSuite.test("customPlaygroundQuickLook") {
   let reallyBigInt: UInt = UInt(Int.max) + 1
   let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   if case let .text(desc) = ptr.customPlaygroundQuickLook {
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
     expectEqual("${SelfName}(0xFFFFFFFF80000000)", desc)
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
     expectEqual("${SelfName}(0x8000000000000000)", desc)

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -128,6 +128,7 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   expectEqual(array2, array1)
 }
 
+#if !os(WASI)
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 30, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
@@ -159,6 +160,7 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
   expected.withUnsafeBytes { expectEqualSequence($0,buffer[0..<idx]) }
   expectEqualSequence([5, 4, 3],bound)
 }
+#endif
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 24, alignment: MemoryLayout<UInt>.alignment)
@@ -172,12 +174,14 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
   expectEqualSequence([5, 4, 3],bound)
 }
 
+#if !os(WASI)
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr") {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
   let source: [Int64] = [5, 4, 3, 2, 1]
   expectCrashLater()
   _ = buffer.initializeMemory(as: Int64.self, from: source)
 }
+#endif
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr") {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
@@ -280,6 +284,7 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
   expectEqualSequence(firstHalf, secondHalf)
 }
 
+#if !os(WASI)
 UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
@@ -512,6 +517,7 @@ UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
     }
   }
 }
+#endif
 
 UnsafeRawBufferPointerTestSuite.test("copy.overlap") {
   let bytes = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: MemoryLayout<UInt>.alignment)

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -200,6 +200,7 @@ func checkPtr(
   }
 }
 
+#if !os(WASI)
 UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:") {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   check(Check.Disjoint)
@@ -220,6 +221,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Righ
     check(Check.RightOverlap)
   }
 }
+#endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from:") {
   let check =


### PR DESCRIPTION
This change disables these kinds of test suite and add ifdef condition for wasm32 and WASI

1. Dynamic linking
2. Dynamic Replacement
3. Address Sanitizer of clang
4. Expecting crash of process
