### PR TITLE
[WASM] Fix KeyPath on WebAssembly

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -222,7 +222,8 @@ getAccessorForComputedComponent(IRGenModule &IGM,
       componentArgsBuf = params.claimNext();
       // Pass the argument pointer down to the underlying function, if it
       // wants it.
-      if (hasSubscriptIndices) {
+      // Always forward extra argument to match callee and caller signature on WebAssembly
+      if (hasSubscriptIndices || IGM.TargetInfo.OutputObjectFormat == llvm::Triple::Wasm) {
         forwardedArgs.add(componentArgsBuf);
       }
       break;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -277,7 +277,7 @@ void verifyKeyPathComponent(SILModule &M,
                 SILFunctionTypeRepresentation::Thin,
               "getter should be a thin function");
       
-      require(substGetterType->getNumParameters() == 1 + hasIndices,
+      require(substGetterType->getNumParameters() == 1 + (hasIndices || C.LangOpts.Target.isOSBinFormatWasm()),
               "getter should have one parameter");
       auto baseParam = substGetterType->getParameters()[0];
       require(baseParam.getConvention() == normalArgConvention,
@@ -325,7 +325,7 @@ void verifyKeyPathComponent(SILModule &M,
                 SILFunctionTypeRepresentation::Thin,
               "setter should be a thin function");
       
-      require(substSetterType->getNumParameters() == 2 + hasIndices,
+      require(substSetterType->getNumParameters() == 2 + (hasIndices || C.LangOpts.Target.isOSBinFormatWasm()),
               "setter should have two parameters");
 
       auto newValueParam = substSetterType->getParameters()[0];

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2543,9 +2543,19 @@ internal protocol KeyPathPatternVisitor {
 
 internal func _resolveRelativeAddress(_ base: UnsafeRawPointer,
                                       _ offset: Int32) -> UnsafeRawPointer {
+  #if arch(wasm32)
+  // FIXME: If offset is 0, it means the pointer is null.
+  // For real relative pointer, it always calculate valid non-null address
+  // because the base address is always valid.
+  // But hacked absolute pointer can be null pointer.
+  // The return type doesn't allow nil, so return given base temporarily.
+  if offset == 0 { return base }
+  return UnsafeRawPointer(bitPattern: Int(offset)).unsafelyUnwrapped
+  #else
   // Sign-extend the offset to pointer width and add with wrap on overflow.
   return UnsafeRawPointer(bitPattern: Int(bitPattern: base) &+ Int(offset))
     .unsafelyUnwrapped
+  #endif
 }
 internal func _resolveRelativeIndirectableAddress(_ base: UnsafeRawPointer,
                                                   _ offset: Int32)
@@ -3189,7 +3199,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
 
     case .pointer:
       // Resolve the sign-extended relative reference.
-      var absoluteID: UnsafeRawPointer? = idValueBase + Int(idValue)
+      var absoluteID: UnsafeRawPointer? = _resolveRelativeAddress(idValueBase, idValue)
 
       // If the pointer ID is unresolved, then it needs work to get to
       // the final value.
@@ -3287,7 +3297,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
       for i in externalArgs.indices {
         let base = externalArgs.baseAddress.unsafelyUnwrapped + i
         let offset = base.pointee
-        let metadataRef = UnsafeRawPointer(base) + Int(offset)
+        let metadataRef = _resolveRelativeAddress(UnsafeRawPointer(base), offset)
         let result = _resolveKeyPathGenericArgReference(
                        metadataRef,
                        genericEnvironment: genericEnvironment,

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2545,7 +2545,7 @@ internal func _resolveRelativeAddress(_ base: UnsafeRawPointer,
                                       _ offset: Int32) -> UnsafeRawPointer {
   #if arch(wasm32)
   // FIXME: If offset is 0, it means the pointer is null.
-  // For real relative pointer, it always calculate valid non-null address
+  // For real relative pointer, it always calculates valid non-null address
   // because the base address is always valid.
   // But hacked absolute pointer can be null pointer.
   // The return type doesn't allow nil, so return given base temporarily.

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -422,6 +422,7 @@ keyPath.test("optional force-unwrapping") {
   expectTrue(value.questionableCanary === newCanary)
 }
 
+#if !os(WASI)
 keyPath.test("optional force-unwrapping trap") {
   let origin_x = \TestOptional.origin!.x
   var value = TestOptional(origin: nil)
@@ -429,6 +430,7 @@ keyPath.test("optional force-unwrapping trap") {
   expectCrashLater()
   _ = value[keyPath: origin_x]
 }
+#endif
 
 struct TestOptional2 {
   var optional: TestOptional?


### PR DESCRIPTION
- https://github.com/swiftwasm/swift/pull/252/commits/e95e714f5ed83dfb0b2eff6a045dceb859c1137b Resolve KeyPath address absolutely instead of relatively
- https://github.com/swiftwasm/swift/pull/252/commits/59cc02c0b0a82ae91eb8beabaab5312012819fe9  Always emit extra argument for indexing and generic parameter. This is necessary to match callee and caller signature on WebAssembly.


This PR makes `test/stdlib/KeyPath.swift` passed 🎉 
