### PR TITLE
Fix test part 4

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -711,7 +711,7 @@ namespace {
         }
 
         static const llvm::StringLiteral vaListNames[] = {
-          "va_list", "__gnuc_va_list", "__va_list"
+          "va_list", "__gnuc_va_list", "__isoc_va_list", "__va_list"
         };
 
         ImportHint hint = ImportHint::None;

--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -128,6 +128,7 @@ MAP_STDLIB_TYPE("u_int64_t", UnsignedInt, 64, "UInt64", false, DoNothing)
 // There's an explicit workaround in ImportType.cpp's VisitDecayedType for that.
 MAP_STDLIB_TYPE("va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__gnuc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
+MAP_STDLIB_TYPE("__isoc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 
 // libkern/OSTypes.h types.

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -565,7 +565,7 @@ final internal class __VaListBuilder {
     // supported vararg type is greater than the alignment of Int, such
     // as non-iOS ARM. Note that we can't use alignof because it
     // differs from ABI alignment on some architectures.
-#if arch(arm) && !os(iOS)
+#if (arch(arm) && !os(iOS)) || arch(wasm32)
     if let arg = arg as? _CVarArgAligned {
       let alignmentInWords = arg._cVarArgAlignment / MemoryLayout<Int>.size
       let misalignmentInWords = count % alignmentInWords

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1376,7 +1376,7 @@ elif run_os == 'wasi':
            config.swift_test_options, config.swift_frontend_test_options)
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = 'wasmer run --'
+    config.target_run = 'wasmer run --backend cranelift --'
     if 'interpret' in lit_config.params:
         use_interpreter_for_simple_runs()
     config.target_sil_opt = (

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1376,7 +1376,7 @@ elif run_os == 'wasi':
            config.swift_test_options, config.swift_frontend_test_options)
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = 'wasmtime --'
+    config.target_run = 'wasmer run --'
     if 'interpret' in lit_config.params:
         use_interpreter_for_simple_runs()
     config.target_sil_opt = (

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -105,6 +105,7 @@ ErrorTests.test("default domain and code") {
 
 enum SillyError: Error { case JazzHands }
 
+#if !os(WASI)
 ErrorTests.test("try!")
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
@@ -127,6 +128,7 @@ ErrorTests.test("try!/location")
     expectCrashLater()
     let _: () = try! { throw SillyError.JazzHands }()
 }
+#endif
 
 ErrorTests.test("try?") {
   var value = try? { () throws -> Int in return 1 }()
@@ -191,6 +193,7 @@ ErrorTests.test("test dealloc empty error box") {
   }
 }
 
+#if !os(WASI)
 var errors: [Error] = []
 ErrorTests.test("willThrow") {
   if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
@@ -215,6 +218,7 @@ ErrorTests.test("willThrow") {
     expectEqual(SillyError.self, type(of: errors.last!))
   }
 }
+#endif
 
 runAllTests()
 

--- a/test/stdlib/FlatMapDeprecation.swift
+++ b/test/stdlib/FlatMapDeprecation.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -swift-version 4 -typecheck -verify  %s
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 func flatMapOnSequence<
   S : Sequence

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -12,6 +12,7 @@
 // -*- swift -*-
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -957,6 +957,7 @@ mirrors.test("Addressing") {
   expectNil(m.descendant(1, 1, "bork"))
 }
 
+#if !os(WASI)
 mirrors.test("Invalid Path Type")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -968,6 +969,7 @@ mirrors.test("Invalid Path Type")
   expectCrashLater()
   _ = m.descendant(X())
 }
+#endif
 
 mirrors.test("PlaygroundQuickLook") {
   // Customization works.

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -706,7 +706,7 @@ Reflection.test("multiprotocolTypes") {
 var BitTwiddlingTestSuite = TestSuite("BitTwiddling")
 
 BitTwiddlingTestSuite.test("_pointerSize") {
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
   expectEqual(4, MemoryLayout<Optional<AnyObject>>.size)
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   expectEqual(8, MemoryLayout<Optional<AnyObject>>.size)
@@ -730,7 +730,7 @@ BitTwiddlingTestSuite.test("_isPowerOf2/Int") {
   expectTrue(_isPowerOf2(asInt(2)))
   expectFalse(_isPowerOf2(asInt(3)))
   expectTrue(_isPowerOf2(asInt(1024)))
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
   // Not applicable to 32-bit architectures.
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   expectTrue(_isPowerOf2(asInt(0x8000_0000)))

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -319,6 +319,7 @@ StringTests.test("SameTypeComparisons") {
   expectFalse(xs != xs)
 }
 
+#if !os(WASI)
 StringTests.test("CompareStringsWithUnpairedSurrogates")
   .xfail(
     .always("<rdar://problem/18029104> Strings referring to underlying " +
@@ -334,6 +335,7 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
     ]
   )
 }
+#endif
 
 StringTests.test("[String].joined() -> String") {
   let s = ["hello", "world"].joined()

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -17,12 +17,9 @@ cd $SWIFT_PATH
 
 ./utils/update-checkout --clone --scheme wasm --skip-repository swift
 
-# Install wasmtime
+# Install wasmer
 
-sudo mkdir /opt/wasmtime && cd /opt/wasmtime
-wget -O - "https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-v0.8.0-x86_64-linux.tar.xz" | \
-  sudo tar Jx --strip-components 1
-sudo ln -sf /opt/wasmtime/* /usr/local/bin
+curl https://get.wasmer.io -sSfL | sh
 
 cd $SOURCE_PATH
 

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -3,20 +3,13 @@
 set -ex
 
 brew uninstall python@2 || true
-brew install cmake ninja llvm sccache
+brew install cmake ninja llvm sccache wasmer
 
 SOURCE_PATH="$( cd "$(dirname $0)/../../../../" && pwd  )"
 SWIFT_PATH=$SOURCE_PATH/swift
 cd $SWIFT_PATH
 
 ./utils/update-checkout --clone --scheme wasm --skip-repository swift
-
-# Install wasmtime
-
-sudo mkdir /opt/wasmtime && cd /opt/wasmtime
-wget -O - "https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-v0.8.0-x86_64-macos.tar.xz" | \
-  sudo tar Jx --strip-components 1
-sudo ln -sf /opt/wasmtime/* /usr/local/bin
 
 cd $SOURCE_PATH
 


### PR DESCRIPTION
This patch includes:

- https://github.com/swiftwasm/swift/pull/451/commits/c74876ab8f79d3a9defe1a3aac55cb9b5f8fc0f6 Fix C variadic parameter interpolation
  - Support va_list of musl named `__isoc_va_list`
  - Change to align parameters
`float` is 8-bytes aligned on wasm32 and 8-bytes is greater than the alignment of Int. So the va_list storage should be explicitly aligned.


- https://github.com/swiftwasm/swift/pull/451/commits/29a89d759827508cd0d0e156994004207181023f Fix test/stdlib/Error.swift
  - Skip test cases that expect a crash
  - Skip `willThrow` test case because wasm doesn't support dynamic symbol loading. `pointerToSwiftCoreSymbol` uses dlsym.
- https://github.com/swiftwasm/swift/pull/451/commits/a0f48aa21b88b65fdb40c30e1fc9bf58d6390bf8 Use wasmer instead of wasmtime
  - wasmer is a little faster than wasmtime :smile:
  - The default singlepass backend  has some bugs around memory access, so use cranelift backend instead. https://github.com/swiftwasm/swift/pull/451/commits/ba7116f93a623e49d9da4e8a4f72b18b67efc3f1
- https://github.com/swiftwasm/swift/pull/451/commits/cf2b7ea427fb83445d03a57d24ebf98bd7616216 Fix test/stdlib/FlatMapDeprecation.swift
  - Use target-typecheck-verify-swift instead to propagate target specific compiler flags
- https://github.com/swiftwasm/swift/pull/451/commits/74275405b3fddb71d21721fbae065ed95c14516b test/stdlib/InputStream.swift.gyb
  - This test case requires sub-process, so disable at this time.
- https://github.com/swiftwasm/swift/pull/451/commits/e5252082e7424edb20afdfc1b8471b273271d4f5 test/stdlib/Mirror.swift
  - Skip test cases that expect a crash
- https://github.com/swiftwasm/swift/pull/451/commits/a7d49ca1957b9746d8e58beea760113d878a9389 test/stdlib/Runtime.swift.gyb
  - Add arch(wasm32) condition to test 32bit memory layout
- https://github.com/swiftwasm/swift/pull/451/commits/f371b792a2d6e49a57b9a8f6d59b46384dec6b3f test/stdlib/StringAPI.swift
  - Disable always failing test case


## News

After this and https://github.com/swiftwasm/llvm-project/pull/4 are merged, all test suites in `test/stdlib` succeed. 