### PR TITLE
Revert thunk emission code completely

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -398,17 +398,10 @@ if (Builtin.ID == BuiltinValueKind::id) { \
     call->addAttribute(llvm::AttributeList::FirstArgIndex + 1,
                        llvm::Attribute::ReadOnly);
 
-    // Remove swiftself and swifterror attribute to match signature generated from
-    // RuntimeFunctions.def. These two parameters are passed using swifterror and swiftself,
-    // but the definition of swift_willThrow generated from the def file doesn't have those
-    // attributes due to the def file limitation. In WebAssembly context, these attributes are
-    // lowered as usual parameters, so this doesn't have any side effects.
-    if (IGF.IGM.TargetInfo.OutputObjectFormat != llvm::Triple::Wasm) {
-      auto attrs = call->getAttributes();
-      IGF.IGM.addSwiftSelfAttributes(attrs, 0);
-      IGF.IGM.addSwiftErrorAttributes(attrs, 1);
-      call->setAttributes(attrs);
-    }
+    auto attrs = call->getAttributes();
+    IGF.IGM.addSwiftSelfAttributes(attrs, 0);
+    IGF.IGM.addSwiftErrorAttributes(attrs, 1);
+    call->setAttributes(attrs);
 
     IGF.Builder.CreateStore(llvm::ConstantPointerNull::get(IGF.IGM.ErrorPtrTy),
                             errorBuffer);

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -54,10 +54,6 @@ namespace irgen {
       CanSILFunctionType origType, CanSILFunctionType substType,
       CanSILFunctionType outType, Explosion &out, bool isOutlined);
 
-
-  llvm::Function *getThinToThickForwarder(IRGenModule &IGM,
-                                          const Optional<FunctionPointer> &staticFnPtr,
-                                          const CanSILFunctionType origType);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -553,9 +553,17 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     AtomicBoolAlign = Alignment(ClangASTContext->getTypeSize(atomicBoolTy));
   }
 
+  // On WebAssembly, tail optional arguments are not allowed because wasm requires
+  // callee and caller signature should be same. So LLVM adds dummy arguments for
+  // swiftself and swifterror. If there is swiftself but there isn't swifterror in
+  // a swiftcc function or invocation, then LLVM adds dummy swifterror parameter or
+  // argument. To count up how many dummy arguments should be added, we need to mark
+  // it as swifterror even though it's not in register.
+  //
+  // TODO: Before sending patch, please rename `IsSwiftErrorInRegister` to `ShouldUseSwiftError`
   IsSwiftErrorInRegister =
     clang::CodeGen::swiftcall::isSwiftErrorLoweredInRegister(
-      ClangCodeGen->CGM());
+      ClangCodeGen->CGM()) || TargetInfo.OutputObjectFormat == llvm::Triple::Wasm;
 
 #ifndef NDEBUG
   sanityCheckStdlib(*this);
@@ -761,6 +769,19 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
     fn->addAttributes(llvm::AttributeList::FunctionIndex, buildFnAttr);
     fn->addAttributes(llvm::AttributeList::ReturnIndex, buildRetAttr);
     fn->addParamAttrs(0, buildFirstParamAttr);
+
+    // Add swiftself and swifterror attributes only when swift_willThrow
+    // swift_willThrow is defined in RuntimeFunctions.def, but due to the
+    // DSL limitation, arguments attributes are not set.
+    // On the other hand, caller of swift_willThrow assumes that it's attributed
+    // with swiftself and swifterror.
+    // This mismatch of attributes would be issue when lowering to WebAssembly.
+    // While lowering, LLVM count up how many dummy params are necssary to match
+    // callee and caller signature. So we need to add them correctly.
+    if (functionName == "swift_willThrow") {
+      fn->addParamAttr(0, Attribute::AttrKind::SwiftSelf);
+      fn->addParamAttr(1, Attribute::AttrKind::SwiftError);
+    }
   }
 
   return cache;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2885,23 +2885,10 @@ TypeConverter::checkFunctionForABIDifferences(SILModule &M,
       return ABIDifference::NeedsThunk;
   }
 
-  // There is no ABI compatibility between non-throws and throws on WebAssembly,
-  // so need thunk.
-  if (M.getASTContext().LangOpts.Target.isOSBinFormatWasm()) {
-    if (!fnTy1->hasErrorResult() && fnTy2->hasErrorResult()) {
-      return ABIDifference::NeedsThunk;
-    }
-  }
-
   auto rep1 = fnTy1->getRepresentation(), rep2 = fnTy2->getRepresentation();
   if (rep1 != rep2) {
     if (rep1 == SILFunctionTypeRepresentation::Thin &&
         rep2 == SILFunctionTypeRepresentation::Thick) {
-      // There is no ABI compatibility between thin and thick on WebAssembly,
-      // so need thunk.
-      if (M.getASTContext().LangOpts.Target.isOSBinFormatWasm()) {
-        return ABIDifference::NeedsThunk;
-      }
       if (DifferentFunctionTypesHaveDifferentRepresentation) {
         // FIXME: check whether the representations are compatible modulo
         // context

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -206,21 +206,9 @@ SWIFT_RUNTIME_STDLIB_API
 void swift_errorRelease(SwiftError *object);
 
 /// Breakpoint hook for debuggers.
-#ifdef __wasm__
-// Notes:
-// Remove swiftself and swifterror attribute to match signature generated from
-// RuntimeFunctions.def. These two parameters are passed using swifterror and swiftself,
-// but the definition of swift_willThrow generated from the def file doesn't have those
-// attributes due to the def file limitation. In WebAssembly context, these attributes are
-// lowered as usual parameters, so this doesn't have any side effects.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-void swift_willThrow(void *unused,
-                     SwiftError **object);
-#else
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 void swift_willThrow(SWIFT_CONTEXT void *unused,
                      SWIFT_ERROR_RESULT SwiftError **object);
-#endif
 
 /// Halt in response to an error.
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API LLVM_ATTRIBUTE_NORETURN

--- a/stdlib/public/runtime/ErrorObjectCommon.cpp
+++ b/stdlib/public/runtime/ErrorObjectCommon.cpp
@@ -27,17 +27,9 @@ using namespace swift;
 void (*swift::_swift_willThrow)(SwiftError *error);
 
 /// Breakpoint hook for debuggers, and calls _swift_willThrow if set.
-#ifdef __wasm__
-// Notes:
-// The reason of this ifdef is described in header file.
-SWIFT_CC(swift) void
-swift::swift_willThrow(void *unused, SwiftError **error)
-#else
 SWIFT_CC(swift) void
 swift::swift_willThrow(SWIFT_CONTEXT void *unused,
-                       SWIFT_ERROR_RESULT SwiftError **error)
-#endif
-{
+                       SWIFT_ERROR_RESULT SwiftError **error) {
   // Cheap check to bail out early, since we expect there to be no callbacks
   // the vast majority of the time.
   if (SWIFT_LIKELY(!_swift_willThrow))


### PR DESCRIPTION
Revert https://github.com/swiftwasm/swift/pull/6 because LLVM can lower swifterror correctly now.

LLVM change is here https://reviews.llvm.org/D76049