### PR TITLE
Fix help text in driver_arguments.py

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1088,7 +1088,8 @@ def create_argument_parser():
                 'Currently only armv7 and aarch64 are supported. '
                 '%(default)s is the default.')
 
-    in_group('Build settings for Android')
+    # -------------------------------------------------------------------------
+    in_group('Build settings for WebAssembly')
 
     option('--wasi-sdk', store_path,
            help='An absolute path to WASI SDK that will be used as a libc '


### PR DESCRIPTION
Current `in_group` argument is misleading as it mentions Android for the WebAssembly arguments group.
