### PR TITLE
Print SDK path when MissingUnderlyingModule

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -706,6 +706,8 @@ ERROR(serialization_circular_dependency,Fatal,
       (StringRef, Identifier))
 ERROR(serialization_missing_underlying_module,Fatal,
       "cannot load underlying module for %0", (Identifier))
+NOTE(serialization_missing_underlying_module_sdk_path,none,
+      "looking for module at this SDK path: %0", (StringRef))
 ERROR(serialization_name_mismatch,Fatal,
       "cannot load module '%0' as '%1'", (StringRef, StringRef))
 ERROR(serialization_name_mismatch_repl,none,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -809,6 +809,10 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
         llvm::Triple(llvm::sys::getProcessTriple()).isMacOSX()) {
       Ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk);
       Ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk_xcrun);
+    } else {
+      Ctx.Diags.diagnose(SourceLoc(), 
+                         diag::serialization_missing_underlying_module_sdk_path,
+                         Ctx.SearchPathOpts.SDKPath);
     }
     break;
   }


### PR DESCRIPTION
I hope this additional diagnostic helps in fixing #713.