### PR TITLE
Copy Dispatch and Clang from upstream toolchain

### DIFF
--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -61,7 +61,8 @@ cd $TMP_DIR/$TOOLCHAIN_NAME
 
 # Merge wasi-sdk and toolchain
 cp -r $WASI_SDK_PATH/lib/clang usr/lib
-cp $WASI_SDK_PATH/bin/* usr/bin
+cp -a $SOURCE_PATH/build/Ninja-ReleaseAssert/llvm-*/bin/clang* usr/bin
+cp -a $WASI_SDK_PATH/bin/*ld usr/bin
 cp -r $WASI_SDK_PATH/share/wasi-sysroot usr/share
 
 # Build SwiftPM and install it into toolchain
@@ -73,7 +74,7 @@ sed -i -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" $TMP_DIR/$
 # Copy nightly-toolchain's host environment stdlib into toolchain
 
 if [[ "$(uname)" == "Linux" ]]; then
-  cp -r $NIGHTLY_TOOLCHAIN/usr/lib/swift/linux $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/swift
+  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/* $TMP_DIR/$TOOLCHAIN_NAME/usr/lib || true
 else
   cp -r $NIGHTLY_TOOLCHAIN/usr/lib/swift/macosx $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/swift
 fi

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -75,7 +75,9 @@ sed -i -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" $TMP_DIR/$
 # Copy nightly-toolchain's host environment stdlib into toolchain
 
 if [[ "$(uname)" == "Linux" ]]; then
-  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/* $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
+  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/lib* $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
+  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/swift $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
+  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/swift_static $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
 else
   cp -r $NIGHTLY_TOOLCHAIN/usr/lib/swift/macosx $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/swift
 fi

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -42,7 +42,6 @@ $BUILD_SCRIPT \
   --swift-install-components "autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;testsuite-tools;toolchain-tools;license;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers;clang-resource-dir-symlink"
   --llvm-install-components "clang" \
   --install-swift \
-  --llvm-install-components "clang" \
   --darwin-toolchain-bundle-identifier="${BUNDLE_IDENTIFIER}" \
   --darwin-toolchain-display-name="${DISPLAY_NAME}" \
   --darwin-toolchain-display-name-short="${DISPLAY_NAME_SHORT}" \

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -39,7 +39,7 @@ $BUILD_SCRIPT \
   --install_destdir="$SOURCE_PATH/install" \
   --installable_package="$INSTALLABLE_PACKAGE" \
   --install-prefix=/$TOOLCHAIN_NAME/usr \
-  --swift-install-components "autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;testsuite-tools;toolchain-tools;license;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers;clang-resource-dir-symlink"
+  --swift-install-components "autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;testsuite-tools;toolchain-tools;license;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers;clang-resource-dir-symlink" \
   --llvm-install-components "clang" \
   --install-swift \
   --darwin-toolchain-bundle-identifier="${BUNDLE_IDENTIFIER}" \

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -75,9 +75,9 @@ sed -i -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" $TMP_DIR/$
 # Copy nightly-toolchain's host environment stdlib into toolchain
 
 if [[ "$(uname)" == "Linux" ]]; then
-  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/lib* $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
-  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/swift $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
-  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/swift_static $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
+  # Avoid to copy usr/lib/swift/clang because our toolchain's one is a directory
+  # but nightly's one is symbolic link, so fail to merge them.
+  rsync -a $NIGHTLY_TOOLCHAIN/usr/lib/ $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/ --exclude 'swift/clang'
 else
   cp -r $NIGHTLY_TOOLCHAIN/usr/lib/swift/macosx $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/swift
 fi

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -40,6 +40,7 @@ $BUILD_SCRIPT \
   --installable_package="$INSTALLABLE_PACKAGE" \
   --install-prefix=/$TOOLCHAIN_NAME/usr \
   --install-swift \
+  --llvm-install-components "clang" \
   --darwin-toolchain-bundle-identifier="${BUNDLE_IDENTIFIER}" \
   --darwin-toolchain-display-name="${DISPLAY_NAME}" \
   --darwin-toolchain-display-name-short="${DISPLAY_NAME_SHORT}" \
@@ -61,7 +62,6 @@ cd $TMP_DIR/$TOOLCHAIN_NAME
 
 # Merge wasi-sdk and toolchain
 cp -r $WASI_SDK_PATH/lib/clang usr/lib
-cp -a $SOURCE_PATH/build/Ninja-ReleaseAssert/llvm-*/bin/clang* usr/bin
 cp -a $WASI_SDK_PATH/bin/*ld usr/bin
 cp -r $WASI_SDK_PATH/share/wasi-sysroot usr/share
 

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -39,6 +39,8 @@ $BUILD_SCRIPT \
   --install_destdir="$SOURCE_PATH/install" \
   --installable_package="$INSTALLABLE_PACKAGE" \
   --install-prefix=/$TOOLCHAIN_NAME/usr \
+  --swift-install-components "autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;testsuite-tools;toolchain-tools;license;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers;clang-resource-dir-symlink"
+  --llvm-install-components "clang" \
   --install-swift \
   --llvm-install-components "clang" \
   --darwin-toolchain-bundle-identifier="${BUNDLE_IDENTIFIER}" \
@@ -74,7 +76,7 @@ sed -i -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" $TMP_DIR/$
 # Copy nightly-toolchain's host environment stdlib into toolchain
 
 if [[ "$(uname)" == "Linux" ]]; then
-  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/* $TMP_DIR/$TOOLCHAIN_NAME/usr/lib || true
+  cp -a $NIGHTLY_TOOLCHAIN/usr/lib/* $TMP_DIR/$TOOLCHAIN_NAME/usr/lib
 else
   cp -r $NIGHTLY_TOOLCHAIN/usr/lib/swift/macosx $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/swift
 fi


### PR DESCRIPTION
Resolve #713. This should copy modulemaps and headers and shouldn't overwrite any wasm libraries. `clang` binaries are now longer copied from the upstream snapshot instead of `wasi-sdk`, as the latter can't builf for host architectures (at least on Linux).