### PR TITLE
Fix Linux build requiring GLIBCXX_3.4.26

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Free disk space
         run: |
           df -h
-          sudo apt-get purge libgcc-9-dev gcc-9
+          sudo apt-get purge libgcc-9-dev gcc-9 libstdc++-9-dev
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Free disk space
         run: |
           df -h
+          sudo apt-get purge libgcc-9-dev gcc-9
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean


### PR DESCRIPTION
Currently when you install our Linux development snapshot on `ubuntu:18.04` Docker image, running `swift` will fail with this error:

```
swift-wasm-DEVELOPMENT-SNAPSHOT-2020-04-26-a/usr/bin/swift: 
/usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found 
(required by swift-wasm-DEVELOPMENT-SNAPSHOT-2020-04-26-a/usr/bin/swift)
```

It looks like Ubuntu on GitHub CI has gcc 9 installed, which isn't available in Ubuntu 18.04 Docker images. These packages should be uninstalled before building the snapshot, hope this will also free up some disk space.