### PR TITLE
Install WASI ICU dependency with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -892,10 +892,13 @@ function(swift_icu_variables_set sdk arch result)
 endfunction()
 
 if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
-  file(DOWNLOAD 
-    "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
-    "${SWIFT_SOURCE_DIR}/../icu.tar.xz"
-    EXPECTED_HASH MD5=25943864ebbfff15cf5aee8d9d5cc4d7)
+  set(WASI_ICU_URL "" CACHE STRING
+    "Download URL for the WASI ICU distribution")
+  set(WASI_ICU_MD5 "" CACHE STRING
+    "The expected has of the WASI ICU distribution archive")
+
+  file(DOWNLOAD "${WASI_ICU_URL}" "${SWIFT_SOURCE_DIR}/../icu.tar.xz"
+    EXPECTED_HASH MD5=${WASI_ICU_MD5})
 
     get_filename_component(SWIFT_SOURCE_BASEDIR "${SWIFT_SOURCE_DIR}" DIRECTORY)
     set(WASI_ICU_DISTRIBUTION_TARGET)
@@ -903,10 +906,12 @@ if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
       COMMAND 
         ${CMAKE_COMMAND} -E 
           tar xfv "${SWIFT_SOURCE_BASEDIR}/icu.tar.xz"
+      WORKING_DIRECTORY 
+        "${SWIFT_SOURCE_BASEDIR}"
       OUTPUT
-        ${SWIFT_WASI_wasm32_ICU_UC}
-        ${SWIFT_WASI_wasm32_ICU_I18N}
-        ${SWIFT_WASI_wasm32_ICU_DATA})
+        "${SWIFT_WASI_wasm32_ICU_UC}"
+        "${SWIFT_WASI_wasm32_ICU_I18N}"
+        "${SWIFT_WASI_wasm32_ICU_DATA}")
 endif()
 
 # ICU is provided through CoreFoundation on Darwin.  On other hosts, if the ICU

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,7 +895,7 @@ if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
   set(WASI_ICU_URL "" CACHE STRING
     "Download URL for the WASI ICU distribution")
   set(WASI_ICU_MD5 "" CACHE STRING
-    "The expected has of the WASI ICU distribution archive")
+    "The expected MD5 hash of the WASI ICU distribution archive")
 
   file(DOWNLOAD "${WASI_ICU_URL}" "${SWIFT_SOURCE_DIR}/../icu.tar.xz"
     EXPECTED_HASH MD5=${WASI_ICU_MD5})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,6 +897,16 @@ endfunction()
 # need to be defined when cross-compiling.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
+    if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
+      file(DOWNLOAD 
+        "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
+        icu.tar.xz
+        EXPECTED_HASH MD5=25943864ebbfff15cf5aee8d9d5cc4d7)
+
+      add_custom_target(wasi_icu_binaries ALL 
+        COMMAND ${CMAKE_COMMAND} -E tar xfv icu.tar.xz "${SWIFT_SOURCE_DIR}/..")
+    endif()
+
     swift_icu_variables_set("${SWIFT_PRIMARY_VARIANT_SDK}"
                             "${SWIFT_PRIMARY_VARIANT_ARCH}"
                             ICU_CONFIGURED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,25 +897,28 @@ if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
   set(WASI_ICU_MD5 "" CACHE STRING
     "The expected has of the WASI ICU distribution archive")
 
-  set(WASI_ICU_OUT_LIB "${SWIFT_SOURCE_BASEDIR}/icu_out/lib")
-  set(SWIFT_WASI_wasm32_ICU_UC_INCLUDE "${SWIFT_SOURCE_BASEDIR}/icu_out/include")
-  set(SWIFT_WASI_wasm32_ICU_I18N_INCLUDE "${SWIFT_SOURCE_BASEDIR}/icu_out/include")
-
   file(DOWNLOAD "${WASI_ICU_URL}" "${SWIFT_SOURCE_DIR}/../icu.tar.xz"
     EXPECTED_HASH MD5=${WASI_ICU_MD5})
 
-    get_filename_component(SWIFT_SOURCE_BASEDIR "${SWIFT_SOURCE_DIR}" DIRECTORY)
-    set(WASI_ICU_DISTRIBUTION_TARGET)
-    add_custom_command_target(WASI_ICU_DISTRIBUTION_TARGET
-      COMMAND 
-        ${CMAKE_COMMAND} -E 
-          tar xfv "${SWIFT_SOURCE_BASEDIR}/icu.tar.xz"
-      WORKING_DIRECTORY 
-        "${SWIFT_SOURCE_BASEDIR}"
-      OUTPUT
-        "${WASI_ICU_OUT_LIB}/libicudata.a"
-        "${WASI_ICU_OUT_LIB}/libicui18n.a"
-        "${WASI_ICU_OUT_LIB}/libicuuc.a")
+  get_filename_component(SWIFT_SOURCE_BASEDIR "${SWIFT_SOURCE_DIR}" DIRECTORY)
+  set(WASI_ICU_OUT_LIB "${SWIFT_SOURCE_BASEDIR}/icu_out/lib")
+  set(SWIFT_WASI_wasm32_ICU_UC_INCLUDE "${SWIFT_SOURCE_BASEDIR}/icu_out/include")
+  set(SWIFT_WASI_wasm32_ICU_I18N_INCLUDE "${SWIFT_SOURCE_BASEDIR}/icu_out/include")
+  set(SWIFT_WASI_wasm32_ICU_UC "${WASI_ICU_OUT_LIB}/libicuuc.a")
+  set(SWIFT_WASI_wasm32_ICU_I18N "${WASI_ICU_OUT_LIB}/libicui18n.a")
+  set(SWIFT_WASI_wasm32_ICU_DATA "${WASI_ICU_OUT_LIB}/libicudata.a")
+
+  set(WASI_ICU_DISTRIBUTION_TARGET)
+  add_custom_command_target(WASI_ICU_DISTRIBUTION_TARGET
+    COMMAND 
+      ${CMAKE_COMMAND} -E 
+        tar xfv "${SWIFT_SOURCE_BASEDIR}/icu.tar.xz"
+    WORKING_DIRECTORY 
+      "${SWIFT_SOURCE_BASEDIR}"
+    OUTPUT
+      "${SWIFT_WASI_wasm32_ICU_DATA}"
+      "${SWIFT_WASI_wasm32_ICU_I18N}"
+      "${SWIFT_WASI_wasm32_ICU_UC}")
 endif()
 
 # ICU is provided through CoreFoundation on Darwin.  On other hosts, if the ICU

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,22 +891,30 @@ function(swift_icu_variables_set sdk arch result)
   endif()
 endfunction()
 
+if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
+  file(DOWNLOAD 
+    "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
+    "${SWIFT_SOURCE_DIR}/../icu.tar.xz"
+    EXPECTED_HASH MD5=25943864ebbfff15cf5aee8d9d5cc4d7)
+
+    get_filename_component(SWIFT_SOURCE_BASEDIR "${SWIFT_SOURCE_DIR}" DIRECTORY)
+    set(WASI_ICU_DISTRIBUTION_TARGET)
+    add_custom_command_target(WASI_ICU_DISTRIBUTION_TARGET
+      COMMAND 
+        ${CMAKE_COMMAND} -E 
+          tar xfv "${SWIFT_SOURCE_BASEDIR}/icu.tar.xz"
+      OUTPUT
+        ${SWIFT_WASI_wasm32_ICU_UC}
+        ${SWIFT_WASI_wasm32_ICU_I18N}
+        ${SWIFT_WASI_wasm32_ICU_DATA})
+endif()
+
 # ICU is provided through CoreFoundation on Darwin.  On other hosts, if the ICU
 # unicode and i18n include and library paths are not defined, perform a standard
 # package lookup.  Otherwise, rely on the paths specified by the user.  These
 # need to be defined when cross-compiling.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
-    if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
-      file(DOWNLOAD 
-        "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
-        icu.tar.xz
-        EXPECTED_HASH MD5=25943864ebbfff15cf5aee8d9d5cc4d7)
-
-      add_custom_target(wasi_icu_binaries ALL 
-        COMMAND ${CMAKE_COMMAND} -E tar xfv icu.tar.xz "${SWIFT_SOURCE_DIR}/..")
-    endif()
-
     swift_icu_variables_set("${SWIFT_PRIMARY_VARIANT_SDK}"
                             "${SWIFT_PRIMARY_VARIANT_ARCH}"
                             ICU_CONFIGURED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,6 +897,10 @@ if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
   set(WASI_ICU_MD5 "" CACHE STRING
     "The expected has of the WASI ICU distribution archive")
 
+  set(WASI_ICU_OUT_LIB "${SWIFT_SOURCE_BASEDIR}/icu_out/lib")
+  set(SWIFT_WASI_wasm32_ICU_UC_INCLUDE "${SWIFT_SOURCE_BASEDIR}/icu_out/include")
+  set(SWIFT_WASI_wasm32_ICU_I18N_INCLUDE "${SWIFT_SOURCE_BASEDIR}/icu_out/include")
+
   file(DOWNLOAD "${WASI_ICU_URL}" "${SWIFT_SOURCE_DIR}/../icu.tar.xz"
     EXPECTED_HASH MD5=${WASI_ICU_MD5})
 
@@ -909,9 +913,9 @@ if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
       WORKING_DIRECTORY 
         "${SWIFT_SOURCE_BASEDIR}"
       OUTPUT
-        "${SWIFT_WASI_wasm32_ICU_UC}"
-        "${SWIFT_WASI_wasm32_ICU_I18N}"
-        "${SWIFT_WASI_wasm32_ICU_DATA}")
+        "${WASI_ICU_OUT_LIB}/libicudata.a"
+        "${WASI_ICU_OUT_LIB}/libicui18n.a"
+        "${WASI_ICU_OUT_LIB}/libicuuc.a")
 endif()
 
 # ICU is provided through CoreFoundation on Darwin.  On other hosts, if the ICU

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -96,7 +96,7 @@ function(swift_create_stdlib_targets name variant define_all_alias)
 
     if(sdk STREQUAL "WASI")
       add_dependencies(${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}${variant} wasi_icu_binaries)
-    endif
+    endif()
 
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       set(target_variant -${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch})

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -94,6 +94,10 @@ function(swift_create_stdlib_targets name variant define_all_alias)
       PROPERTIES
       FOLDER "Swift libraries/Aggregate")
 
+    if(sdk STREQUAL "WASI")
+      add_dependencies(${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}${variant} wasi_icu_binaries)
+    endif
+
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       set(target_variant -${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch})
 

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -94,10 +94,6 @@ function(swift_create_stdlib_targets name variant define_all_alias)
       PROPERTIES
       FOLDER "Swift libraries/Aggregate")
 
-    if(sdk STREQUAL "WASI")
-      add_dependencies(${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}${variant} wasi_icu_binaries)
-    endif()
-
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       set(target_variant -${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch})
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -374,7 +374,6 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
       foreach(module IN LISTS icu_modules)
         set(module_lib "${SWIFT_WASI_wasm32_ICU_${module}}")
         get_filename_component(module_lib_name ${module_lib} NAME)
-        message("swift_icu_${module}_${sdk} depends on ${module_lib}")
         add_custom_command_target(swift_icu_${module}_${sdk}
           COMMAND
             "${CMAKE_COMMAND}" -E copy

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -358,8 +358,8 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
       add_custom_command_target(swift_static_stdlib_${sdk}_args
         COMMAND
           "${CMAKE_COMMAND}" -E copy
-        "${linkfile_src}"
-          "${SWIFTSTATICLIB_DIR}/${linkfile}"
+            "${linkfile_src}"
+            "${SWIFTSTATICLIB_DIR}/${linkfile}"
         OUTPUT
           "${SWIFTSTATICLIB_DIR}/${linkfile}"
         DEPENDS
@@ -374,6 +374,7 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
       foreach(module IN LISTS icu_modules)
         set(module_lib "${SWIFT_WASI_wasm32_ICU_${module}}")
         get_filename_component(module_lib_name ${module_lib} NAME)
+        message("swift_icu_${module}_${sdk} depends on ${module_lib}")
         add_custom_command_target(swift_icu_${module}_${sdk}
           COMMAND
             "${CMAKE_COMMAND}" -E copy

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -27,7 +27,14 @@ set(swift_stubs_c_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
 list(APPEND swift_stubs_c_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_stubs_c_compile_flags -I${SWIFT_SOURCE_DIR}/include)
 
+set(swift_stubs_dependencies)
+if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WASI")
+  list(APPEND swift_stubs_dependencies ${WASI_ICU_DISTRIBUTION_TARGET})
+endif()
+
 add_swift_target_library(swiftStdlibStubs
+                  DEPENDS
+                    ${swift_stubs_dependencies}
                   OBJECT_LIBRARY
                     ${swift_stubs_sources}
                     ${swift_stubs_objc_sources}

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2473,6 +2473,8 @@ darwin-toolchain-alias=swift
 
 mixin-preset=webassembly
 extra-cmake-options=
+    -DWASI_ICU_URL:STRING="https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
+    -DWASI_ICU_MD5:STRING="25943864ebbfff15cf5aee8d9d5cc4d7"
     -DSWIFT_PRIMARY_VARIANT_SDK:STRING=WASI
     -DSWIFT_PRIMARY_VARIANT_ARCH:STRING=wasm32
     -DSWIFT_SDKS='WASI;LINUX'
@@ -2486,6 +2488,8 @@ extra-cmake-options=
 
 mixin-preset=webassembly
 extra-cmake-options=
+    -DWASI_ICU_URL:STRING="https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
+    -DWASI_ICU_MD5:STRING="25943864ebbfff15cf5aee8d9d5cc4d7"
     -DSWIFT_PRIMARY_VARIANT_SDK:STRING=WASI
     -DSWIFT_PRIMARY_VARIANT_ARCH:STRING=wasm32
     -DSWIFT_OSX_x86_64_ICU_STATICLIB=TRUE

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2447,11 +2447,6 @@ build-swift-static-sdk-overlay
 build-swift-static-stdlib
 llvm-targets-to-build=X86;WebAssembly
 stdlib-deployment-targets=wasi-wasm32
-wasi-icu-data=%(SOURCE_PATH)s/icu_out/lib/libicudata.a
-wasi-icu-i18n=%(SOURCE_PATH)s/icu_out/lib/libicui18n.a
-wasi-icu-i18n-include=%(SOURCE_PATH)s/icu_out/include
-wasi-icu-uc=%(SOURCE_PATH)s/icu_out/lib/libicuuc.a
-wasi-icu-uc-include=%(SOURCE_PATH)s/icu_out/include
 wasi-sdk=%(SOURCE_PATH)s/wasi-sdk
 
 [preset: webassembly-installable]

--- a/utils/build-script
+++ b/utils/build-script
@@ -215,18 +215,9 @@ def validate_arguments(toolchain, args):
                 "--android-icu-i18n-include, and --android-icu-data "
                 "must be specified")
     if args.wasm:
-        if args.wasi_sdk is None or \
-                args.wasi_icu_uc is None or \
-                args.wasi_icu_uc_include is None or \
-                args.wasi_icu_i18n is None or \
-                args.wasi_icu_i18n_include is None or \
-                args.wasi_icu_data is None:
+        if args.wasi_sdk is None:
             diagnostics.fatal(
-                "when building for WebAssembly, --wasi-sdk, "
-                "--wasi-icu-uc, "
-                "--wasi-icu-uc-include, --wasi-icu-i18n, "
-                "--wasi-icu-i18n-include, and --wasi-icu-data "
-                "must be specified")
+                "when building for WebAssembly, --wasi-sdk must be specified")
 
     targets_needing_toolchain = [
         'build_indexstoredb',
@@ -696,11 +687,6 @@ class BuildScriptInvocation(object):
         if args.wasm:
             impl_args += [
                 "--wasi-sdk", args.wasi_sdk,
-                "--wasi-icu-uc", args.wasi_icu_uc,
-                "--wasi-icu-uc-include", args.wasi_icu_uc_include,
-                "--wasi-icu-i18n", args.wasi_icu_i18n,
-                "--wasi-icu-i18n-include", args.wasi_icu_i18n_include,
-                "--wasi-icu-data", args.wasi_icu_data,
             ]
 
         if platform.system() == 'Darwin':

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -118,11 +118,6 @@ KNOWN_SETTINGS=(
 
     ## WebAssembly/WASI Options
     wasi-sdk                                      ""                "An absolute path to the WASI SDK that will be used as a libc implementation for Wasm builds"
-    wasi-icu-uc                                   ""                "Path to libicuuc.so"
-    wasi-icu-uc-include                           ""                "Path to a directory containing headers for libicuuc"
-    wasi-icu-i18n                                 ""                "Path to libicui18n.so"
-    wasi-icu-i18n-include                         ""                "Path to a directory containing headers libicui18n"
-    wasi-icu-data                                 ""                "Path to libicudata.so"
 
     ## Build Types for Components
     swift-stdlib-build-type                       "Debug"           "the CMake build variant for Swift"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1617,11 +1617,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_WASI_SDK_PATH:STRING="${WASI_SDK}"
-                        -DSWIFT_WASI_wasm32_ICU_UC:STRING="${WASI_ICU_UC}"
-                        -DSWIFT_WASI_wasm32_ICU_UC_INCLUDE:STRING="${WASI_ICU_UC_INCLUDE}"
-                        -DSWIFT_WASI_wasm32_ICU_I18N:STRING="${WASI_ICU_I18N}"
-                        -DSWIFT_WASI_wasm32_ICU_I18N_INCLUDE:STRING="${WASI_ICU_I18N_INCLUDE}"
-                        -DSWIFT_WASI_wasm32_ICU_DATA:STRING="${WASI_ICU_DATA}"
                     )
                 fi
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1098,17 +1098,6 @@ def create_argument_parser():
            help='An absolute path to WASI SDK that will be used as a libc '
                 'implementation for Wasm builds')
 
-    option('--wasi-icu-uc', store_path,
-           help='Path to libicuuc.so')
-    option('--wasi-icu-uc-include', store_path,
-           help='Path to a directory containing headers for libicuuc')
-    option('--wasi-icu-i18n', store_path,
-           help='Path to libicui18n.so')
-    option('--wasi-icu-i18n-include', store_path,
-           help='Path to a directory containing headers libicui18n')
-    option('--wasi-icu-data', store_path,
-           help='Path to libicudata.so')
-
     # -------------------------------------------------------------------------
     in_group('Experimental language features')
 

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -42,9 +42,6 @@ mv $WASI_SDK_FULL_NAME ./wasi-sdk
 # with os and environment name `getMultiarchTriple`.
 ln -s wasm32-wasi wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi-unknown
 
-wget -O icu.tar.xz "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
-tar xf icu.tar.xz
-
 # Install sccache
 
 sudo mkdir /opt/sccache && cd /opt/sccache

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -27,6 +27,3 @@ ln -s ../include wasi-sdk/share/wasi-sysroot/usr/include
 # Link wasm32-wasi-unknown to wasm32-wasi because clang finds crt1.o from sysroot
 # with os and environment name `getMultiarchTriple`.
 ln -s wasm32-wasi wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi-unknown
-
-wget -O icu.tar.xz "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
-tar xf icu.tar.xz


### PR DESCRIPTION
This makes the dependency installation step more portable, allowing it to be run on Windows. Also makes it much more likely to be accepted upstream, as opposed to bash scripts.

Additionally, it prevents downloading and unpacking ICU twice if you call `ci.sh` command twice in a row. This is thanks to `file(DOWNLOAD)` command checking if the file is downloaded, while unpacking is implemented as a custom CMake target.