### PR TITLE
Revert "Always build static library for WASM"

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1451,18 +1451,13 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerOutputType = file_types::TY_Object;
       break;
 
-    case options::OPT_emit_library: {
-      // WebAssembly only support static library
-      if (TC.getTriple().isOSBinFormatWasm()) {
-        OI.LinkAction = LinkKind::StaticLibrary;
-      } else {
-        OI.LinkAction = Args.hasArg(options::OPT_static) ?
-                        LinkKind::StaticLibrary :
-                        LinkKind::DynamicLibrary;
-      }
+    case options::OPT_emit_library:
+      OI.LinkAction = Args.hasArg(options::OPT_static) ?
+                      LinkKind::StaticLibrary :
+                      LinkKind::DynamicLibrary;
       OI.CompilerOutputType = file_types::TY_Object;
       break;
-    }
+
     case options::OPT_static:
       break;
 


### PR DESCRIPTION
This reverts commit 60d5dbd97ad04a963a3f7a5ede51b21daea66f03.

As discussed in https://github.com/apple/swift/pull/31691 it would be better to require users to pass `-static` explicitly when emitting a library. This would also keep an option of dynamic linking open for the future, when there's a clear path for dynamic linking support in WASI and WebAssembly in general.