### PR TITLE
Add CMake toolchain for cross-compiling Swift

### DIFF
--- a/utils/webassembly/toolchain-wasi.cmake
+++ b/utils/webassembly/toolchain-wasi.cmake
@@ -1,0 +1,28 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR wasm32)
+set(triple wasm32-unknown-wasi)
+
+set(WASI_SDK_PREFIX "${SWIFT_SOURCE_PREFIX}/wasi-sdk")
+
+set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang)
+set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++)
+set(CMAKE_AR ${WASI_SDK_PREFIX}/bin/llvm-ar CACHE STRING "wasi-sdk build")
+set(CMAKE_RANLIB ${WASI_SDK_PREFIX}/bin/llvm-ranlib CACHE STRING "wasi-sdk build")
+set(CMAKE_C_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
+set(CMAKE_CXX_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-threads" CACHE STRING "wasi-sdk build")
+
+set(CMAKE_SYSROOT ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
+set(CMAKE_STAGING_PREFIX ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
+
+# Don't look in the sysroot for executables to run during the build
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# Only look in the sysroot (not in the host paths) for the rest
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)
+
+# Some other hacks
+set(CMAKE_C_COMPILER_WORKS ON)
+set(CMAKE_CXX_COMPILER_WORKS ON)


### PR DESCRIPTION
This toolchain file is what I use to cross-compile Foundation with CMake. Even though Foundation still isn't fully working, I'm thinking this toolchain file is worth keeping in the repository in case anyone would like to collaborate on it.

I use it with this invocation in the Foundation build directory (usually `build/Ninja-ReleaseAssert/foundation-wasi-wasm32`):

```sh
cmake -G Ninja \
  -DCMAKE_TOOLCHAIN_FILE=../../../swift/utils/webassembly/toolchain-wasi.cmake \
  -DICU_ROOT=../../../icu_out -DICU_DEBUG=ON -DBUILD_SHARED_LIBS=OFF \
  ../../../swift-corelibs-foundation
```