### PR TITLE
Re-enable exclusivity checking when targeting __wasm__

### DIFF
--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -47,11 +47,7 @@
 
 using namespace swift;
 
-#ifdef __wasm__
-bool swift::_swift_disableExclusivityChecking = true;
-#else
 bool swift::_swift_disableExclusivityChecking = false;
-#endif
 
 static const char *getAccessName(ExclusivityFlags flags) {
   switch (flags) {


### PR DESCRIPTION
As suggested upstream at apple#31693, exclusivity checking should work just fine in single-threaded environments. I also haven't noticed any issues in my local builds.