### PR TITLE
Build Foundation and add it to the distribution

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -67,7 +67,7 @@
                 "cmark": "master",
                 "llbuild": "master",
                 "swiftpm": "swiftwasm",
-                "swift-argument-parser": "0.0.5",
+                "swift-argument-parser": "0.0.6",
                 "swift-driver": "master",
                 "swift-syntax": "master",
                 "swift-stress-tester": "master",

--- a/utils/webassembly/build-foundation.sh
+++ b/utils/webassembly/build-foundation.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -ex
+DESTINATION_TOOLCHAIN=$1
+SOURCE_PATH="$(cd "$(dirname $0)/../../.." && pwd)"
+
+# Remove host CoreFoundation (which can be different from the target) headers
+# to avoid shadowing the wasm32 target CoreFoundation
+rm -rf $DESTINATION_TOOLCHAIN/usr/lib/swift/CoreFoundation
+
+FOUNDATION_BUILD="$SOURCE_PATH/build/Ninja-ReleaseAssert/foundation-wasi-wasm32"
+
+mkdir -p $FOUNDATION_BUILD
+cd $FOUNDATION_BUILD
+
+cmake -G Ninja \
+  -DCMAKE_Swift_COMPILER="$DESTINATION_TOOLCHAIN/usr/bin/swiftc" \
+  -DCMAKE_STAGING_PREFIX="$DESTINATION_TOOLCHAIN/usr" \
+  -DCMAKE_TOOLCHAIN_FILE="$SOURCE_PATH/swift/utils/webassembly/toolchain-wasi.cmake" \
+  -DWASI_SDK_PATH="$SOURCE_PATH/wasi-sdk" \
+  -DICU_ROOT="$SOURCE_PATH/icu_out" \
+  -DBUILD_SHARED_LIBS=OFF \
+  "${SOURCE_PATH}/swift-corelibs-foundation"
+  
+ninja -v
+ninja -v install
+
+# On macOS the target CoreFoundation shadows the CoreFoundation suppplied by Xcode.
+# On Linux though there's no system CoreFoundation, its headers have to be shipped
+# in the installable archive and serve for both host and target.
+if [[ "$(uname)" == "Darwin" ]]; then
+  mv $DESTINATION_TOOLCHAIN/usr/lib/swift/CoreFoundation \
+    $DESTINATION_TOOLCHAIN/usr/lib/swift/wasi/wasm32/CoreFoundation
+fi

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -35,6 +35,9 @@ BUNDLE_IDENTIFIER="swiftwasm.${YEAR}${MONTH}${DAY}"
 DISPLAY_NAME_SHORT="Swift for WebAssembly Development Snapshot"
 DISPLAY_NAME="${DISPLAY_NAME_SHORT} ${YEAR}-${MONTH}-${DAY}"
 
+# Make sure Clang headers install dir exists to avoid broken symlinks
+mkdir -p $SOURCE_PATH/install/$TOOLCHAIN_NAME/usr/lib/clang/10.0.0
+
 $SOURCE_PATH/swift/utils/build-script --preset=$PRESET_NAME \
   SOURCE_PATH="$SOURCE_PATH" \
   INSTALLABLE_PACKAGE="$INSTALLABLE_PACKAGE" \
@@ -76,6 +79,8 @@ if [[ "$(uname)" == "Linux" ]]; then
 else
   cp -r $NIGHTLY_TOOLCHAIN/usr/lib/swift/macosx $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/swift
 fi
+
+$UTILS_PATH/build-foundation.sh $TMP_DIR/$TOOLCHAIN_NAME
 
 cd $TMP_DIR
 tar cfz $PACKAGE_ARTIFACT $TOOLCHAIN_NAME

--- a/utils/webassembly/install-wasi-sdk.sh
+++ b/utils/webassembly/install-wasi-sdk.sh
@@ -1,0 +1,18 @@
+#/bin/bash
+
+set -ex
+
+SOURCE_PATH="$( cd "$(dirname $0)/../../../" && pwd  )"
+
+cd $SOURCE_PATH
+
+WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-$2-latest.tgz.zip"
+
+[ ! -e dist-wasi-sdk.tgz.zip ] && \
+  wget -O dist-wasi-sdk.tgz.zip $WASI_SDK_URL
+unzip -u dist-wasi-sdk.tgz.zip -d .
+WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
+WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -$1.tar.gz)
+tar xfz $WASI_SDK_TAR_PATH
+rm -rf ./wasi-sdk
+mv $WASI_SDK_FULL_NAME ./wasi-sdk

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -20,23 +20,23 @@ cd $SWIFT_PATH
 
 # Install wasmer
 
-curl https://get.wasmer.io -sSfL | sh
+if [ ! -e ~/.wasmer/bin/wasmer ]; then
+  curl https://get.wasmer.io -sSfL | sh
+fi
 
 cd $SOURCE_PATH
 
-wget -O install_cmake.sh "https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-Linux-x86_64.sh"
-chmod +x install_cmake.sh
-sudo mkdir -p /opt/cmake
-sudo ./install_cmake.sh --skip-license --prefix=/opt/cmake
-sudo ln -sf /opt/cmake/bin/* /usr/local/bin
+if [ -z $(which cmake) ]; then
+  wget -O install_cmake.sh "https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2-Linux-x86_64.sh"
+  chmod +x install_cmake.sh
+  sudo mkdir -p /opt/cmake
+  sudo ./install_cmake.sh --skip-license --prefix=/opt/cmake
+  sudo ln -sf /opt/cmake/bin/* /usr/local/bin
+fi
+
 cmake --version
 
-wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-ubuntu-latest.tgz.zip"
-unzip dist-wasi-sdk.tgz.zip -d .
-WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
-WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -linux.tar.gz)
-tar xfz $WASI_SDK_TAR_PATH
-mv $WASI_SDK_FULL_NAME ./wasi-sdk
+$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh linux ubuntu
 
 # Link wasm32-wasi-unknown to wasm32-wasi because clang finds crt1.o from sysroot
 # with os and environment name `getMultiarchTriple`.
@@ -44,7 +44,9 @@ ln -s wasm32-wasi wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi-unknown
 
 # Install sccache
 
-sudo mkdir /opt/sccache && cd /opt/sccache
-wget -O - "https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz" | \
-  sudo tar xz --strip-components 1
-sudo ln -sf /opt/sccache/sccache /usr/local/bin
+if [ -z $(which sccache) ]; then
+  sudo mkdir /opt/sccache && cd /opt/sccache
+  wget -O - "https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz" | \
+    sudo tar xz --strip-components 1
+  sudo ln -sf /opt/sccache/sccache /usr/local/bin
+fi

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -13,16 +13,7 @@ cd $SWIFT_PATH
 
 cd $SOURCE_PATH
 
-WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
-
-[ ! -e dist-wasi-sdk.tgz.zip ] && \
-  wget -O dist-wasi-sdk.tgz.zip $WASI_SDK_URL
-unzip -u dist-wasi-sdk.tgz.zip -d .
-WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
-WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -macos.tar.gz)
-tar xfz $WASI_SDK_TAR_PATH
-rm -rf ./wasi-sdk
-mv $WASI_SDK_FULL_NAME ./wasi-sdk
+$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh macos macos
 
 # Link sysroot/usr/include to sysroot/include because Darwin sysroot doesn't 
 # find header files in sysroot/include but sysroot/usr/include

--- a/utils/webassembly/toolchain-wasi.cmake
+++ b/utils/webassembly/toolchain-wasi.cmake
@@ -1,20 +1,17 @@
-set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_NAME WASI)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
 set(triple wasm32-unknown-wasi)
 
-set(WASI_SDK_PREFIX "${SWIFT_SOURCE_PREFIX}/wasi-sdk")
-
-set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang)
-set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++)
-set(CMAKE_AR ${WASI_SDK_PREFIX}/bin/llvm-ar CACHE STRING "wasi-sdk build")
-set(CMAKE_RANLIB ${WASI_SDK_PREFIX}/bin/llvm-ranlib CACHE STRING "wasi-sdk build")
+set(CMAKE_C_COMPILER "${WASI_SDK_PATH}/bin/clang")
+set(CMAKE_CXX_COMPILER "${WASI_SDK_PATH}/bin/clang++")
+set(CMAKE_AR "${WASI_SDK_PATH}/bin/llvm-ar" CACHE STRING "wasi-sdk build")
+set(CMAKE_RANLIB "${WASI_SDK_PATH}/bin/llvm-ranlib" CACHE STRING "wasi-sdk build")
 set(CMAKE_C_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
 set(CMAKE_CXX_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-threads" CACHE STRING "wasi-sdk build")
 
-set(CMAKE_SYSROOT ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
-set(CMAKE_STAGING_PREFIX ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
+set(CMAKE_SYSROOT ${WASI_SDK_PATH}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
 
 # Don't look in the sysroot for executables to run during the build
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
Bits of the dependency installation scripts were refactored to make the local development a bit easier.

Overall, Foundation is not fully working yet [due to the OOB bug](https://github.com/swiftwasm/swift/issues/592#issuecomment-628245662), and to link with it you need build with SwiftPM with `swift build --destination destination.json` where `destination.json` looks like this on Linux with root path (because of absolute paths, the destination file has to be adapted for every `swiftenv` installation, I think this should be automated in the future):

```json
{
  "version": 1,
  "target": "wasm32-unknown-wasi",
  "sdk": "/usr/share/wasi-sysroot",
  "toolchain-bin-dir": "/usr/bin/",
  "extra-cc-flags": [],
  "extra-swiftc-flags": [
    "-I", "/usr/lib/swift/wasi/wasm32",
    "-Xlinker", "-lCoreFoundation",
    "-Xlinker", "-lBlocksRuntime",
    "-Xlinker", "-licui18n",
    "-Xlinker", "-luuid"
  ],
  "extra-cpp-flags": []
}
```

The reasoning for shipping Foundation anyway in the nightly distribution is to provide an easier way to reproduce the bug. And even after the bug is fixed, I think the Foundation build/installation steps would stay the same, at least as long as we continue to use `build-script`.

Related to #592.
Closes #658.