### PR TITLE
Make macOS dependencies script idempotent

### DIFF
--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -13,7 +13,8 @@ cd $SWIFT_PATH
 
 cd $SOURCE_PATH
 
-[ ! -e dist-wasi-sdk.tgz.zip ] && wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
+[ ! -e dist-wasi-sdk.tgz.zip ] && \
+  wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
 unzip -u dist-wasi-sdk.tgz.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -macos.tar.gz)

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -13,8 +13,10 @@ cd $SWIFT_PATH
 
 cd $SOURCE_PATH
 
+WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
+
 [ ! -e dist-wasi-sdk.tgz.zip ] && \
-  wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
+  wget -O dist-wasi-sdk.tgz.zip $WASI_SDK_URL
 unzip -u dist-wasi-sdk.tgz.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -macos.tar.gz)

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -13,11 +13,12 @@ cd $SWIFT_PATH
 
 cd $SOURCE_PATH
 
-wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
-unzip dist-wasi-sdk.tgz.zip -d .
+[ ! -e dist-wasi-sdk.tgz.zip ] && wget -O dist-wasi-sdk.tgz.zip "https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-macos-latest.tgz.zip"
+unzip -u dist-wasi-sdk.tgz.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -macos.tar.gz)
 tar xfz $WASI_SDK_TAR_PATH
+rm -rf ./wasi-sdk
 mv $WASI_SDK_FULL_NAME ./wasi-sdk
 
 # Link sysroot/usr/include to sysroot/include because Darwin sysroot doesn't 


### PR DESCRIPTION
Currently, when running `ci.sh` twice in a row, it redownloads packages and complains about existing directories.