### PR TITLE
Use clang instead of clang++ in lit.cfg

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -281,7 +281,6 @@ config.swift_remoteast_test = inferSwiftBinary('swift-remoteast-test')
 config.swift_indent = inferSwiftBinary('swift-indent')
 config.swift_symbolgraph_extract = inferSwiftBinary('swift-symbolgraph-extract')
 config.clang = inferSwiftBinary('clang')
-config.clangxx = inferSwiftBinary('clang++')
 config.llvm_link = inferSwiftBinary('llvm-link')
 config.swift_llvm_opt = inferSwiftBinary('swift-llvm-opt')
 config.llvm_profdata = inferSwiftBinary('llvm-profdata')
@@ -1432,7 +1431,7 @@ elif run_os == 'wasi':
         (config.swiftc, config.variant_triple))
     config.target_clang = (
         "%s -target %s %s -fobjc-runtime=ios-5.0" %
-        (config.clangxx, config.variant_triple, clang_mcp_opt))
+        (config.clang, config.variant_triple, clang_mcp_opt))
     config.target_ld = (
         "%s -L%r" % 
         (config.wasm_ld, make_path(test_resource_dir, config.target_sdk_name)))


### PR DESCRIPTION
This is recommended in the review of apple#31695.