### PR TITLE
Fix use of underscores in WebAssembly presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2441,8 +2441,8 @@ wasi-sdk=%(SOURCE_PATH)s/wasi-sdk
 
 [preset: webassembly-installable]
 
-install_destdir=%(SOURCE_PATH)s/install
-installable_package=%(INSTALLABLE_PACKAGE)s
+install-destdir=%(SOURCE_PATH)s/install
+installable-package=%(INSTALLABLE_PACKAGE)s
 install-prefix=/%(TOOLCHAIN_NAME)s/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;testsuite-tools;toolchain-tools;license;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers;clang-resource-dir-symlink
 llvm-install-components=clang


### PR DESCRIPTION
These underscores don't cause issues in current configurations, but when experimenting with other products (e.g. IndexStore) this causes issues where `install-destdir` had different values when passed to `build-script` and to `build-script-impl`.