### PR TITLE
Fix DOWNLOAD_URL in 5.3 install-nightly-toolchain.sh

### DIFF
--- a/utils/webassembly/install-nightly-toolchain.sh
+++ b/utils/webassembly/install-nightly-toolchain.sh
@@ -15,7 +15,7 @@ install_linux() {
   export $(/usr/bin/curl ${BASE_URL}/ubuntu1804/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')
 
   DOWNLOAD_DIR=$(echo $download | sed "s/-ubuntu18.04.tar.gz//g")
-  DOWNLOAD_URL=${BASE_URL}/${DOWNLOAD_DIR}/${download}
+  DOWNLOAD_URL=${BASE_URL}/ubuntu1804/${DOWNLOAD_DIR}/${download}
   /usr/bin/curl ${BASE_URL}/${DOWNLOAD_DIR}/${download} > ${WORKSPACE}/latest_toolchain.tar.gz
 
   mkdir -p ${WORKSPACE}/latest_toolchain

--- a/utils/webassembly/install-nightly-toolchain.sh
+++ b/utils/webassembly/install-nightly-toolchain.sh
@@ -16,7 +16,7 @@ install_linux() {
 
   DOWNLOAD_DIR=$(echo $download | sed "s/-ubuntu18.04.tar.gz//g")
   DOWNLOAD_URL=${BASE_URL}/ubuntu1804/${DOWNLOAD_DIR}/${download}
-  /usr/bin/curl ${BASE_URL}/${DOWNLOAD_DIR}/${download} > ${WORKSPACE}/latest_toolchain.tar.gz
+  /usr/bin/curl $DOWNLOAD_URL > ${WORKSPACE}/latest_toolchain.tar.gz
 
   mkdir -p ${WORKSPACE}/latest_toolchain
   tar xzf ${WORKSPACE}/latest_toolchain.tar.gz -C ${WORKSPACE}/latest_toolchain


### PR DESCRIPTION
5.3 branch builds are currently failing after my attempts to fix SwiftPM due to issues seen in #1253. This should fix the build, but SwiftPM issues are still there. I've described the ongoing investigation in https://github.com/swiftwasm/swift/issues/1365.