### PR TITLE
Merge master 2020-07-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ various products. These incremental builds are a big timesaver when developing
 and debugging.
 
     cd ${SWIFT_BUILD_DIR}
-    ninja swift
+    ninja swift-frontend
 
 This will build the Swift compiler, but will not rebuild the standard library or
 any other target. Building the `swift-stdlib` target as an additional layer of
@@ -269,7 +269,7 @@ To open the Swift project in Xcode, open `${SWIFT_BUILD_DIR}/Swift.xcodeproj`.
 It will auto-create a *lot* of schemes for all of the available targets. A
 common debug flow would involve:
 
- - Select the 'swift' scheme.
+ - Select the 'swift-frontend' scheme.
  - Pull up the scheme editor (⌘⇧<).
  - Select the 'Arguments' tab and click the '+'.
  - Add the command line options.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -121,6 +121,7 @@ function(_add_host_variant_c_compile_link_flags name)
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)
   if (_lto_flag_out)
     target_compile_options(${name} PRIVATE ${_lto_flag_out})
+    target_link_options(${name} PRIVATE ${_lto_flag_out})
   endif()
 endfunction()
 

--- a/docs/StdlibRationales.rst
+++ b/docs/StdlibRationales.rst
@@ -174,21 +174,6 @@ call an API with a different name, say ``lazyEnumerate()`` to opt into
 laziness.  The problem is that the eager API, which would have a shorter and
 less obscure name, would be less efficient for the common case.
 
-Use of ``BooleanType`` in library APIs
---------------------------------------
-
-Use ``Bool`` instead of a generic function over a ``BooleanType``, unless there
-are special circumstances (for example, ``func &&`` is designed to work on all
-boolean values so that ``&&`` feels like a part of the language).
-
-``BooleanType`` is a protocol to which only ``Bool`` and ``ObjCBool`` conform.
-Users don't usually interact ``ObjCBool`` instances, except when using certain
-specific APIs (for example, APIs that operate on pointers to ``BOOL``).  If
-someone already has an ``ObjCBool`` instance for whatever strange reason, they
-can just convert it to ``Bool``.  We think this is the right tradeoff:
-simplifying function signatures is more important than making a marginal
-usecase a bit more convenient.
-
 Possible future directions
 ==========================
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1801,11 +1801,11 @@ ERROR(type_cannot_conform_to_nsobject,none,
 
 ERROR(use_of_equal_instead_of_equality,none,
       "use of '=' in a boolean context, did you mean '=='?", ())
-
 ERROR(type_cannot_conform, none,
-      "%select{|value of protocol }0type %1 cannot conform to %2; "
-      "only struct/enum/class types can conform to protocols",
-      (bool, Type, Type))
+      "%select{type %1|protocol %1 as a type}0 cannot conform to "
+      "%select{%3|the protocol itself}2; "
+      "only concrete types such as structs, enums and classes can conform to protocols",
+      (bool, Type, bool, Type))
 NOTE(required_by_opaque_return,none,
     "required by opaque return type of %0 %1", (DescriptiveDeclKind, DeclName))
 NOTE(required_by_decl,none,

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -59,11 +59,23 @@ EDUCATIONAL_NOTES(property_wrapper_failable_init,
 EDUCATIONAL_NOTES(property_wrapper_type_requirement_not_accessible,
                   "property-wrapper-requirements.md")
 
+EDUCATIONAL_NOTES(opaque_type_var_no_init, "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_no_underlying_type_candidates,
+                  "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_mismatched_underlying_type_candidates,
+                  "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_self_referential_underlying_type,
+                  "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_var_no_underlying_type,
+                  "opaque-type-inference.md")
+
+
 EDUCATIONAL_NOTES(missing_append_interpolation,
                   "string-interpolation-conformance.md")
 EDUCATIONAL_NOTES(append_interpolation_static,
                   "string-interpolation-conformance.md")
 EDUCATIONAL_NOTES(append_interpolation_void_or_discardable,
                   "string-interpolation-conformance.md")
+EDUCATIONAL_NOTES(type_cannot_conform, "protocol-type-non-conformance.md")                
 
 #undef EDUCATIONAL_NOTES

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -785,6 +785,10 @@ public:
   
   /// Check if this is a nominal type defined at the top level of the Swift module
   bool isStdlibType();
+  
+  /// Check if this is either an Array, Set or Dictionary collection type defined
+  /// at the top level of the Swift module
+  bool isKnownStdlibCollectionType();
 
   /// If this is a class type or a bound generic class type, returns the
   /// (possibly generic) class.
@@ -5571,25 +5575,7 @@ public:
   /// find a particular nested type by name, directly, or look at the
   /// protocols to which this archetype conforms.
   ArrayRef<std::pair<Identifier, Type>>
-  getKnownNestedTypes(bool resolveTypes = true) const {
-    return getAllNestedTypes(/*resolveTypes=*/false);
-  }
-
-  /// Retrieve the nested types of this archetype.
-  ///
-  /// \param resolveTypes Whether to eagerly resolve the nested types
-  /// (defaults to \c true). Otherwise, the nested types might be
-  /// null.
-  ///
-  /// FIXME: This operation should go away, because it breaks recursive
-  /// protocol constraints.
-  ArrayRef<std::pair<Identifier, Type>>
-  getAllNestedTypes(bool resolveTypes = true) const;
-
-  /// Set the nested types to a copy of the given array of
-  /// archetypes.
-  void setNestedTypes(ASTContext &Ctx,
-                      ArrayRef<std::pair<Identifier, Type>> Nested);
+  getKnownNestedTypes() const;
 
   /// Register a nested type with the given name.
   void registerNestedType(Identifier name, Type nested);

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -18,7 +18,6 @@
 #ifndef SWIFT_SIL_SILTYPE_H
 #define SWIFT_SIL_SILTYPE_H
 
-#include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/SILLayout.h"
 #include "swift/AST/Types.h"
 #include "llvm/ADT/PointerIntPair.h"
@@ -622,9 +621,18 @@ template<> Can##ID##Type SILType::getAs<ID##Type>() const = delete;  \
 template<> Can##ID##Type SILType::castTo<ID##Type>() const = delete; \
 template<> bool SILType::is<ID##Type>() const = delete;
 NON_SIL_TYPE(Function)
+NON_SIL_TYPE(GenericFunction)
 NON_SIL_TYPE(AnyFunction)
 NON_SIL_TYPE(LValue)
+NON_SIL_TYPE(InOut)
 #undef NON_SIL_TYPE
+
+#define TYPE(ID, PARENT)
+#define UNCHECKED_TYPE(ID, PARENT)                                   \
+template<> Can##ID##Type SILType::getAs<ID##Type>() const = delete;  \
+template<> Can##ID##Type SILType::castTo<ID##Type>() const = delete; \
+template<> bool SILType::is<ID##Type>() const = delete;
+#include "swift/AST/TypeNodes.def"
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILType T) {
   T.print(OS);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -760,6 +760,16 @@ bool TypeBase::isStdlibType() {
   return false;
 }
 
+bool TypeBase::isKnownStdlibCollectionType() {
+  if (auto *structType = getAs<BoundGenericStructType>()) {
+    auto &ctx = getASTContext();
+    auto *decl = structType->getDecl();
+    return decl == ctx.getArrayDecl() || decl == ctx.getDictionaryDecl() ||
+           decl == ctx.getSetDecl();
+  }
+  return false;
+}
+
 /// Remove argument labels from the function type.
 Type TypeBase::removeArgumentLabels(unsigned numArgumentLabels) {
   // If there is nothing to remove, don't.
@@ -3210,7 +3220,11 @@ void ArchetypeType::populateNestedTypes() const {
 
   // Record the nested types.
   auto mutableThis = const_cast<ArchetypeType *>(this);
-  mutableThis->setNestedTypes(mutableThis->getASTContext(), nestedTypes);
+
+  std::sort(nestedTypes.begin(), nestedTypes.end(), OrderArchetypeByName());
+  auto &Ctx = mutableThis->getASTContext();
+  mutableThis->NestedTypes = Ctx.AllocateCopy(nestedTypes);
+  mutableThis->Bits.ArchetypeType.ExpandedNestedTypes = true;
 }
 
 Type ArchetypeType::getNestedType(Identifier Name) const {
@@ -3250,26 +3264,9 @@ bool ArchetypeType::hasNestedType(Identifier Name) const {
 }
 
 ArrayRef<std::pair<Identifier, Type>>
-ArchetypeType::getAllNestedTypes(bool resolveTypes) const {
+ArchetypeType::getKnownNestedTypes() const {
   populateNestedTypes();
-
-  if (resolveTypes) {
-    for (auto &nested : NestedTypes) {
-      if (!nested.second)
-        resolveNestedType(nested);
-    }
-  }
-
   return NestedTypes;
-}
-
-void ArchetypeType::setNestedTypes(
-                                 ASTContext &Ctx,
-                                 ArrayRef<std::pair<Identifier, Type>> Nested) {
-  assert(!Bits.ArchetypeType.ExpandedNestedTypes && "Already expanded");
-  NestedTypes = Ctx.AllocateCopy(Nested);
-  std::sort(NestedTypes.begin(), NestedTypes.end(), OrderArchetypeByName());
-  Bits.ArchetypeType.ExpandedNestedTypes = true;
 }
 
 void ArchetypeType::registerNestedType(Identifier name, Type nested) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3595,6 +3595,18 @@ void ClangImporter::Implementation::lookupValue(
   auto &clangCtx = getClangASTContext();
   auto clangTU = clangCtx.getTranslationUnitDecl();
 
+  // For operators we have to look up static member functions in addition to the
+  // top-level function lookup below.
+  if (name.isOperator()) {
+    for (auto entry : table.lookupMemberOperators(name.getBaseName())) {
+      if (isVisibleClangEntry(entry)) {
+        if (auto decl = dyn_cast<ValueDecl>(
+                importDeclReal(entry->getMostRecentDecl(), CurrentVersion)))
+          consumer.foundDecl(decl, DeclVisibilityKind::VisibleAtTopLevel);
+      }
+    }
+  }
+
   for (auto entry : table.lookup(name.getBaseName(), clangTU)) {
     // If the entry is not visible, skip it.
     if (!isVisibleClangEntry(entry)) continue;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3801,14 +3801,20 @@ namespace {
             decl->isVariadic(), isInSystemModule(dc), name, bodyParams);
 
         if (auto *mdecl = dyn_cast<clang::CXXMethodDecl>(decl)) {
-          if (!mdecl->isStatic()) {
+          if (mdecl->isStatic() ||
+              // C++ operators that are implemented as non-static member
+              // functions get imported into Swift as static member functions
+              // that use an additional parameter for the left-hand side operand
+              // instead of the receiver object.
+              mdecl->getDeclName().getNameKind() ==
+                  clang::DeclarationName::CXXOperatorName) {
+            selfIdx = None;
+          } else {
             selfIdx = 0;
             // Workaround until proper const support is handled: Force
             // everything to be mutating. This implicitly makes the parameter
             // indirect.
             selfIsInOut = true;
-          } else {
-            selfIdx = None;
           }
         }
       }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -27,11 +27,13 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Token.h"
 #include "swift/Strings.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/TypeVisitor.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Lex/Preprocessor.h"
@@ -1707,6 +1709,30 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
   SmallVector<ParamDecl *, 4> parameters;
   unsigned index = 0;
   SmallBitVector nonNullArgs = getNonNullArgs(clangDecl, params);
+
+  // C++ operators that are implemented as non-static member functions get
+  // imported into Swift as static methods that have an additional
+  // parameter for the left-hand side operand instead of the receiver object.
+  if (auto CMD = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
+    if (clangDecl->isOverloadedOperator()) {
+      auto param = new (SwiftContext)
+          ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
+                    SwiftContext.getIdentifier("lhs"), dc);
+
+      auto parent = CMD->getParent();
+      auto parentType = importType(
+          parent->getASTContext().getRecordType(parent),
+          ImportTypeKind::Parameter, allowNSUIntegerAsInt, Bridgeability::None);
+
+      param->setInterfaceType(parentType.getType());
+
+      // Workaround until proper const support is handled: Force everything to
+      // be mutating. This implicitly makes the parameter indirect.
+      param->setSpecifier(ParamSpecifier::InOut);
+
+      parameters.push_back(param);
+    }
+  }
 
   for (auto param : params) {
     auto paramTy = param->getType();

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/Version.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/Preprocessor.h"
@@ -783,6 +784,35 @@ SwiftLookupTable::lookupObjCMembers(SerializedSwiftName baseName) {
     case ContextKind::ObjCProtocol:
     case ContextKind::Typedef:
       break;
+    }
+
+    // Map each of the declarations.
+    for (auto &stored : entry.DeclsOrMacros) {
+      assert(isDeclEntry(stored) && "Not a declaration?");
+      result.push_back(mapStoredDecl(stored));
+    }
+  }
+
+  return result;
+}
+
+SmallVector<clang::NamedDecl *, 4>
+SwiftLookupTable::lookupMemberOperators(SerializedSwiftName baseName) {
+  SmallVector<clang::NamedDecl *, 4> result;
+
+  // Find the lookup table entry for this base name.
+  auto known = findOrCreate(LookupTable, baseName,
+                            [](auto &results, auto &Reader, auto Name) {
+                              return (void)Reader.lookup(Name, results);
+                            });
+  if (known == LookupTable.end())
+    return result;
+
+  // Walk each of the entries.
+  for (auto &entry : known->second) {
+    // We're only looking for C++ operators
+    if (entry.Context.first != ContextKind::Tag) {
+      continue;
     }
 
     // Map each of the declarations.

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -528,6 +528,10 @@ public:
   SmallVector<clang::NamedDecl *, 4>
   lookupObjCMembers(SerializedSwiftName baseName);
 
+  /// Lookup member operators with the given base name, regardless of context.
+  SmallVector<clang::NamedDecl *, 4>
+  lookupMemberOperators(SerializedSwiftName baseName);
+
   /// Retrieve the set of Objective-C categories and extensions.
   ArrayRef<clang::ObjCCategoryDecl *> categories();
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -102,8 +102,6 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.RemarkOnRebuildFromModuleInterface |=
     Args.hasArg(OPT_Rmodule_interface_rebuild);
 
-  Opts.DisableInterfaceFileLock |= Args.hasArg(OPT_disable_interface_lockfile);
-
   computePrintStatsOptions();
   computeDebugTimeOptions();
   computeTBDOptions();
@@ -147,6 +145,15 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   if (Opts.RequestedAction == FrontendOptions::ActionType::NoneAction) {
     Opts.RequestedAction = determineRequestedAction(Args);
+  }
+
+  if (Opts.RequestedAction == FrontendOptions::ActionType::CompileModuleFromInterface) {
+    // The situations where we use this action, e.g. explicit module building and
+    // generating prebuilt module cache, don't need synchronization. We should avoid
+    // using lock files for them.
+    Opts.DisableInterfaceFileLock = true;
+  } else {
+    Opts.DisableInterfaceFileLock |= Args.hasArg(OPT_disable_interface_lockfile);
   }
 
   if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate &&

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -33,6 +33,7 @@
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -18,6 +18,7 @@
 
 #define DEBUG_TYPE "libsil"
 #include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ForeignInfo.h"
@@ -2783,7 +2784,8 @@ getSILFunctionTypeForClangDecl(TypeConverter &TC, const clang::Decl *clangDecl,
   }
 
   if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
-    AbstractionPattern origPattern =
+    AbstractionPattern origPattern = method->isOverloadedOperator() ?
+        AbstractionPattern::getCXXOperatorMethod(origType, method):
         AbstractionPattern::getCXXMethod(origType, method);
     auto conventions = CXXMethodConventions(method);
     return getSILFunctionType(TC, TypeExpansionContext::minimal(), origPattern,
@@ -4039,7 +4041,10 @@ getAbstractionPatternForConstant(ASTContext &ctx, SILDeclRef constant,
       assert(numParameterLists == 2);
       if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
         // C++ method.
-        return AbstractionPattern::getCurriedCXXMethod(fnType, bridgedFn);
+        return method->isOverloadedOperator()
+                   ? AbstractionPattern::getCurriedCXXOperatorMethod(fnType,
+                                                                     bridgedFn)
+                   : AbstractionPattern::getCurriedCXXMethod(fnType, bridgedFn);
       } else {
         // C function imported as a method.
         return AbstractionPattern::getCurriedCFunctionAsMethod(fnType,
@@ -4123,8 +4128,25 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
     }
 
     auto partialFnPattern = bridgingFnPattern.getFunctionResultType();
-    getBridgedParams(rep, partialFnPattern, methodParams, bridgedParams,
-                     bridging);
+    for (unsigned i : indices(methodParams)) {
+      // C++ operators that are implemented as non-static member functions get
+      // imported into Swift as static methods that have an additional
+      // parameter for the left-hand-side operand instead of the receiver
+      // object. These are inout parameters and don't get bridged.
+      // TODO: Undo this if we stop using inout.
+      if (auto method = dyn_cast_or_null<clang::CXXMethodDecl>(
+              constant.getDecl()->getClangDecl())) {
+        if (i==0 && method->isOverloadedOperator()) {
+          bridgedParams.push_back(methodParams[0]);
+          continue;
+        }
+      }
+
+      auto paramPattern = partialFnPattern.getFunctionParamType(i);
+      auto bridgedParam =
+          getBridgedParam(rep, paramPattern, methodParams[i], bridging);
+      bridgedParams.push_back(bridgedParam);
+    }
 
     bridgedResultType =
       getBridgedResultType(rep,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -28,6 +28,7 @@
 #include "Varargs.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/Expr.h"
@@ -2108,7 +2109,8 @@ VarargsInfo Lowering::emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
 }
 
 ManagedValue Lowering::emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
-                                      VarargsInfo &&varargs) {
+                                      VarargsInfo &&varargs,
+                                      unsigned numElements) {
   // Kill the abort cleanup.
   SGF.Cleanups.setCleanupState(varargs.getAbortCleanup(), CleanupState::Dead);
 
@@ -2117,6 +2119,14 @@ ManagedValue Lowering::emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
   if (array.hasCleanup())
     SGF.Cleanups.setCleanupState(array.getCleanup(), CleanupState::Active);
 
+  // Array literals only need to be finalized, if the array is really allocated.
+  // In case of zero elements, no allocation is done, but the empty-array
+  // singleton is used. "Finalization" means to emit an end_cow_mutation
+  // instruction on the array. As the empty-array singleton is a read-only and
+  // shared object, it's not legal to do a end_cow_mutation on it.
+  if (numElements == 0)
+    return array;
+    
   return SGF.emitUninitializedArrayFinalization(loc, std::move(array));
 }
 
@@ -3900,7 +3910,7 @@ RValue RValueEmitter::visitCollectionExpr(CollectionExpr *E, SGFContext C) {
     SGF.Cleanups.setCleanupState(destCleanup, CleanupState::Dead);
 
   RValue array(SGF, loc, arrayType,
-             emitEndVarargs(SGF, loc, std::move(varargsInfo)));
+        emitEndVarargs(SGF, loc, std::move(varargsInfo), E->getNumElements()));
 
   array = scope.popPreservingValue(std::move(array));
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -15,6 +15,7 @@
 #include "ManagedValue.h"
 #include "Scope.h"
 #include "swift/SIL/SILArgument.h"
+#include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ParameterList.h"
 

--- a/lib/SILGen/Varargs.h
+++ b/lib/SILGen/Varargs.h
@@ -68,7 +68,8 @@ VarargsInfo emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
 
 /// Successfully end a varargs emission sequence.
 ManagedValue emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
-                            VarargsInfo &&varargs); 
+                            VarargsInfo &&varargs,
+                             unsigned numElements); 
 
 } // end namespace Lowering
 } // end namespace swift

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -540,13 +540,15 @@ static SILValue emitCodeForConstantArray(ArrayRef<SILValue> elements,
   assert(arrayAllocateFun);
 
   SILFunction *arrayFinalizeFun = nullptr;
-  if (FuncDecl *arrayFinalizeDecl = astContext.getFinalizeUninitializedArray()) {
-    std::string finalizeMangledName =
-        SILDeclRef(arrayFinalizeDecl, SILDeclRef::Kind::Func).mangle();
-    arrayFinalizeFun =
-        module.findFunction(finalizeMangledName, SILLinkage::SharedExternal);
-    assert(arrayFinalizeFun);
-    module.linkFunction(arrayFinalizeFun);
+  if (numElements != 0) {
+    if (FuncDecl *arrayFinalizeDecl = astContext.getFinalizeUninitializedArray()) {
+      std::string finalizeMangledName =
+          SILDeclRef(arrayFinalizeDecl, SILDeclRef::Kind::Func).mangle();
+      arrayFinalizeFun =
+          module.findFunction(finalizeMangledName, SILLinkage::SharedExternal);
+      assert(arrayFinalizeFun);
+      module.linkFunction(arrayFinalizeFun);
+    }
   }
 
   // Call the _allocateUninitializedArray function with numElementsSIL. The

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -246,8 +246,11 @@ public:
   bool tryOptimizeKeypath(ApplyInst *AI);
   bool tryOptimizeInoutKeypath(BeginApplyInst *AI);
   bool tryOptimizeKeypathApplication(ApplyInst *AI, SILFunction *callee);
-  bool tryOptimizeKeypathKVCString(ApplyInst *AI, SILDeclRef callee);
-      
+  bool tryOptimizeKeypathOffsetOf(ApplyInst *AI, FuncDecl *calleeFn,
+                                  KeyPathInst *kp);
+  bool tryOptimizeKeypathKVCString(ApplyInst *AI, FuncDecl *calleeFn,
+                                  KeyPathInst *kp);
+
   // Optimize concatenation of string literals.
   // Constant-fold concatenation of string literals known at compile-time.
   SILInstruction *optimizeConcatenationOfStringLiterals(ApplyInst *AI);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -271,6 +271,130 @@ bool SILCombiner::tryOptimizeKeypathApplication(ApplyInst *AI,
   return true;
 }
 
+/// Replaces a call of the getter of AnyKeyPath._storedInlineOffset with a
+/// "constant" offset, in case of a keypath literal.
+///
+/// "Constant" offset means a series of struct_element_addr and
+/// tuple_element_addr instructions with a 0-pointer as base address.
+/// These instructions can then be lowered to "real" constants in IRGen for
+/// concrete types, or to metatype offset lookups for generic or resilient types.
+///
+/// Replaces:
+///   %kp = keypath ...
+///   %offset = apply %_storedInlineOffset_method(%kp)
+/// with:
+///   %zero = integer_literal $Builtin.Word, 0
+///   %null_ptr = unchecked_trivial_bit_cast %zero to $Builtin.RawPointer
+///   %null_addr = pointer_to_address %null_ptr
+///   %projected_addr = struct_element_addr %null_addr
+///    ... // other address projections
+///   %offset_ptr = address_to_pointer %projected_addr
+///   %offset_builtin_int = unchecked_trivial_bit_cast %offset_ptr
+///   %offset_int = struct $Int (%offset_builtin_int)
+///   %offset = enum $Optional<Int>, #Optional.some!enumelt, %offset_int
+bool SILCombiner::tryOptimizeKeypathOffsetOf(ApplyInst *AI,
+                                             FuncDecl *calleeFn,
+                                             KeyPathInst *kp) {
+  auto *accessor = dyn_cast<AccessorDecl>(calleeFn);
+  if (!accessor || !accessor->isGetter())
+    return false;
+
+  AbstractStorageDecl *storage = accessor->getStorage();
+  DeclName name = storage->getName();
+  if (!name.isSimpleName() ||
+      (name.getBaseIdentifier().str() != "_storedInlineOffset"))
+    return false;
+
+  KeyPathPattern *pattern = kp->getPattern();
+  SubstitutionMap patternSubs = kp->getSubstitutions();
+  CanType rootTy = pattern->getRootType().subst(patternSubs)->getCanonicalType();
+  CanType parentTy = rootTy;
+  
+  // First check if _storedInlineOffset would return an offset or nil. Basically
+  // only stored struct and tuple elements produce an offset. Everything else
+  // (e.g. computed properties, class properties) result in nil.
+  bool hasOffset = true;
+  for (const KeyPathPatternComponent &component : pattern->getComponents()) {
+    switch (component.getKind()) {
+    case KeyPathPatternComponent::Kind::StoredProperty: {
+
+      // Handle the special case of C tail-allocated arrays. IRGen would
+      // generate an undef offset for struct_element_addr of C tail-allocated
+      // arrays.
+      VarDecl *propDecl = component.getStoredPropertyDecl();
+      if (propDecl->hasClangNode() && propDecl->getType()->isVoid())
+        return false;
+
+      if (!parentTy.getStructOrBoundGenericStruct())
+        hasOffset = false;
+      break;
+    }
+    case KeyPathPatternComponent::Kind::TupleElement:
+      break;
+    case KeyPathPatternComponent::Kind::GettableProperty:
+    case KeyPathPatternComponent::Kind::SettableProperty:
+      // We cannot predict the offset of fields in resilient types, because it's
+      // unknown if a resilient field is a computed or stored property.
+      if (component.getExternalDecl())
+        return false;
+      hasOffset = false;
+      break;
+    case KeyPathPatternComponent::Kind::OptionalChain:
+    case KeyPathPatternComponent::Kind::OptionalForce:
+    case KeyPathPatternComponent::Kind::OptionalWrap:
+      hasOffset = false;
+      break;
+    }
+    parentTy = component.getComponentType();
+  }
+
+  SILLocation loc = AI->getLoc();
+  SILValue result;
+
+  if (hasOffset) {
+    SILType rootAddrTy = SILType::getPrimitiveAddressType(rootTy);
+    SILValue rootAddr = Builder.createBaseAddrForOffset(loc, rootAddrTy);
+
+    auto projector = KeyPathProjector::create(kp, rootAddr, loc, Builder);
+    if (!projector)
+      return false;
+
+    // Create the address projections of the keypath.
+    SILType ptrType = SILType::getRawPointerType(Builder.getASTContext());
+    SILValue offsetPtr;
+    projector->project(KeyPathProjector::AccessType::Get, [&](SILValue addr) {
+      offsetPtr = Builder.createAddressToPointer(loc, addr, ptrType);
+    });
+
+    // The result of the _storedInlineOffset call should be Optional<Int>. If
+    // not, something is wrong with the stdlib. Anyway, if it's not like we
+    // expect, bail.
+    SILType intType = AI->getType().getOptionalObjectType();
+    if (!intType)
+      return false;
+    StructDecl *intDecl = intType.getStructOrBoundGenericStruct();
+    if (!intDecl || intDecl->getStoredProperties().size() != 1)
+      return false;
+    VarDecl *member = intDecl->getStoredProperties()[0];
+    CanType builtinIntTy = member->getType()->getCanonicalType();
+    if (!isa<BuiltinIntegerType>(builtinIntTy))
+      return false;
+
+    // Convert the projected address back to an optional integer.
+    SILValue offset = Builder.createUncheckedBitCast(loc, offsetPtr,
+                                SILType::getPrimitiveObjectType(builtinIntTy));
+    SILValue offsetInt = Builder.createStruct(loc, intType, { offset });
+    result = Builder.createOptionalSome(loc, offsetInt, AI->getType());
+  } else {
+    // The keypath has no offset.
+    result = Builder.createOptionalNone(loc, AI->getType());
+  }
+  AI->replaceAllUsesWith(result);
+  eraseInstFromFunction(*AI);
+  ++NumOptimizedKeypaths;
+  return true;
+}
+
 /// Try to optimize a keypath KVC string access on a literal key path.
 ///
 /// Replace:
@@ -279,17 +403,8 @@ bool SILCombiner::tryOptimizeKeypathApplication(ApplyInst *AI,
 /// With:
 ///   %string = string_literal "blah"
 bool SILCombiner::tryOptimizeKeypathKVCString(ApplyInst *AI,
-                                              SILDeclRef callee) {
-  if (AI->getNumArguments() != 1) {
-    return false;
-  }
-  if (!callee.hasDecl()) {
-    return false;
-  }
-  auto calleeFn = dyn_cast<FuncDecl>(callee.getDecl());
-  if (!calleeFn)
-    return false;
-  
+                                              FuncDecl *calleeFn,
+                                              KeyPathInst *kp) {
   if (!calleeFn->getAttrs()
         .hasSemanticsAttr(semantics::KEYPATH_KVC_KEY_PATH_STRING))
     return false;
@@ -298,11 +413,6 @@ bool SILCombiner::tryOptimizeKeypathKVCString(ApplyInst *AI,
   auto &C = calleeFn->getASTContext();
   auto objTy = AI->getType().getOptionalObjectType();
   if (!objTy || objTy.getStructOrBoundGenericStruct() != C.getStringDecl())
-    return false;
-  
-  KeyPathInst *kp
-    = KeyPathProjector::getLiteralKeyPath(AI->getArgument(0));
-  if (!kp || !kp->hasPattern())
     return false;
   
   auto objcString = kp->getPattern()->getObjCString();
@@ -357,10 +467,33 @@ bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
     return tryOptimizeKeypathApplication(AI, callee);
   }
   
-  if (auto method = dyn_cast<ClassMethodInst>(AI->getCallee())) {
-    return tryOptimizeKeypathKVCString(AI, method->getMember());
-  }
+  // Try optimize keypath method calls.
+  auto *methodInst = dyn_cast<ClassMethodInst>(AI->getCallee());
+  if (!methodInst)
+    return false;
   
+  if (AI->getNumArguments() != 1) {
+    return false;
+  }
+
+  SILDeclRef callee = methodInst->getMember();
+  if (!callee.hasDecl()) {
+    return false;
+  }
+  auto *calleeFn = dyn_cast<FuncDecl>(callee.getDecl());
+  if (!calleeFn)
+    return false;
+
+  KeyPathInst *kp = KeyPathProjector::getLiteralKeyPath(AI->getArgument(0));
+  if (!kp || !kp->hasPattern())
+    return false;
+  
+  if (tryOptimizeKeypathOffsetOf(AI, calleeFn, kp))
+    return true;
+
+  if (tryOptimizeKeypathKVCString(AI, calleeFn, kp))
+    return true;
+
   return false;
 }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1035,7 +1035,7 @@ bool TypeVarBindingProducer::computeNext() {
     auto srcLocator = binding.getLocator();
     if (srcLocator &&
         srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() &&
-        !type->hasTypeVariable() && CS.isCollectionType(type)) {
+        !type->hasTypeVariable() && type->isKnownStdlibCollectionType()) {
       // If the type binding comes from the argument conversion, let's
       // instead of binding collection types directly, try to bind
       // using temporary type variables substituted for element

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -500,7 +500,9 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(
   }
 
   emitDiagnostic(diag::type_cannot_conform,
-                 nonConformingType->isExistentialType(), nonConformingType,
+                 nonConformingType->isExistentialType(), 
+                 nonConformingType, 
+                 nonConformingType->isEqual(protocolType),
                  protocolType);
 
   if (auto *OTD = dyn_cast<OpaqueTypeDecl>(AffectedDecl)) {
@@ -2087,7 +2089,8 @@ bool ContextualFailure::diagnoseAsError() {
     if (CTP == CTP_ForEachStmt) {
       if (fromType->isAnyExistentialType()) {
         emitDiagnostic(diag::type_cannot_conform,
-                       /*isExistentialType=*/true, fromType, toType);
+                       /*isExistentialType=*/true, fromType, 
+                       fromType->isEqual(toType), toType);
         return true;
       }
 
@@ -3373,7 +3376,7 @@ bool MissingMemberFailure::diagnoseInLiteralCollectionContext() const {
 
   auto parentType = getType(parentExpr);
 
-  if (!isCollectionType(parentType) && !parentType->is<TupleType>())
+  if (!parentType->isKnownStdlibCollectionType() && !parentType->is<TupleType>())
     return false;
 
   if (isa<TupleExpr>(parentExpr)) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -208,11 +208,6 @@ protected:
       llvm::function_ref<void(GenericTypeParamType *, Type)> substitution =
           [](GenericTypeParamType *, Type) {});
 
-  bool isCollectionType(Type type) const {
-    auto &cs = getConstraintSystem();
-    return cs.isCollectionType(type);
-  }
-
   bool isArrayType(Type type) const {
     auto &cs = getConstraintSystem();
     return bool(cs.isArrayType(type));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3708,7 +3708,7 @@ bool ConstraintSystem::repairFailures(
     // func foo<T>(_: [T]) {}
     // foo(1) // expected '[Int]', got 'Int'
     // ```
-    if (isCollectionType(rhs)) {
+    if (rhs->isKnownStdlibCollectionType()) {
       std::function<Type(Type)> getArrayOrSetType = [&](Type type) -> Type {
         if (auto eltTy = isArrayType(type))
           return getArrayOrSetType(*eltTy);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -878,18 +878,6 @@ Optional<Type> ConstraintSystem::isSetType(Type type) {
   return None;
 }
 
-bool ConstraintSystem::isCollectionType(Type type) {
-  if (auto *structType = type->getAs<BoundGenericStructType>()) {
-    auto &ctx = type->getASTContext();
-    auto *decl = structType->getDecl();
-    if (decl == ctx.getArrayDecl() || decl == ctx.getDictionaryDecl() ||
-        decl == ctx.getSetDecl())
-      return true;
-  }
-
-  return false;
-}
-
 bool ConstraintSystem::isAnyHashableType(Type type) {
   if (auto st = type->getAs<StructType>()) {
     auto &ctx = type->getASTContext();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3348,9 +3348,6 @@ public:
   /// element type of the set.
   static Optional<Type> isSetType(Type t);
 
-  /// Determine if the type in question is one of the known collection types.
-  static bool isCollectionType(Type t);
-
   /// Determine if the type in question is AnyHashable.
   static bool isAnyHashableType(Type t);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -884,6 +884,17 @@ ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           DeclContext *DC,
                                           SourceLoc ComplainLoc = SourceLoc());
 
+/// This is similar to \c conformsToProtocol, but returns \c true for cases where
+/// the type \p T could be dynamically cast to \p Proto protocol, such as a non-final
+/// class where a subclass conforms to \p Proto.
+///
+/// \param DC The context in which to check conformance. This affects, for
+/// example, extension visibility.
+///
+///
+/// \returns True if \p T conforms to the protocol \p Proto, false otherwise.
+bool couldDynamicallyConformToProtocol(Type T, ProtocolDecl *Proto,
+                                       DeclContext *DC);
 /// Completely check the given conformance.
 void checkConformance(NormalProtocolConformance *conformance);
 

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -16,7 +16,7 @@ import Swift
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin.C.tgmath
-#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   import Glibc
 #elseif os(Windows)
   import MSVCRT

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -14,9 +14,9 @@
 
 import Swift
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin.C.tgmath
-#elseif canImport(Glibc)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT

--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing Mach error codes.
 @objc
 public enum MachErrorCode : Int32 {
@@ -202,4 +202,4 @@ public enum MachErrorCode : Int32 {
   /// The requested property cannot be changed at this time.
   case policyStatic             = 51
 }
-#endif // canImport(Darwin)
+#endif // os(macOS) || os(iOS) || os(tvOS) || os(watchOS)

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
 /// Enumeration describing POSIX error codes.
 @objc

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -17,7 +17,7 @@ import SwiftOverlayShims
 import ucrt
 #endif
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 //===----------------------------------------------------------------------===//
 // MacTypes.h
 //===----------------------------------------------------------------------===//
@@ -103,7 +103,7 @@ public var errno : Int32 {
 // stdio.h
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin) || os(FreeBSD) || os(PS4)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(PS4)
 public var stdin : UnsafeMutablePointer<FILE> {
   get {
     return __stdinp
@@ -248,7 +248,7 @@ public var S_IFBLK: mode_t  { return mode_t(0o060000) }
 public var S_IFREG: mode_t  { return mode_t(0o100000) }
 public var S_IFLNK: mode_t  { return mode_t(0o120000) }
 public var S_IFSOCK: mode_t { return mode_t(0o140000) }
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 public var S_IFWHT: mode_t  { return mode_t(0o160000) }
 #endif
 
@@ -271,7 +271,7 @@ public var S_ISUID: mode_t  { return mode_t(0o004000) }
 public var S_ISGID: mode_t  { return mode_t(0o002000) }
 public var S_ISVTX: mode_t  { return mode_t(0o001000) }
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 public var S_ISTXT: mode_t  { return S_ISVTX }
 public var S_IREAD: mode_t  { return S_IRUSR }
 public var S_IWRITE: mode_t { return S_IWUSR }
@@ -315,7 +315,7 @@ public func ioctl(
 // unistd.h
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 @available(*, unavailable, message: "Please use threads or posix_spawn*()")
 public func fork() -> Int32 {
   fatalError("unavailable function can't be called")
@@ -331,7 +331,7 @@ public func vfork() -> Int32 {
 // signal.h
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 public var SIG_DFL: sig_t? { return nil }
 public var SIG_IGN: sig_t { return unsafeBitCast(1, to: sig_t.self) }
 public var SIG_ERR: sig_t { return unsafeBitCast(-1, to: sig_t.self) }
@@ -395,10 +395,10 @@ public typealias Semaphore = UnsafeMutablePointer<sem_t>
 
 /// The value returned by `sem_open()` in the case of failure.
 public var SEM_FAILED: Semaphore? {
-#if canImport(Darwin)
-  // The value is ABI.  Value verified to be correct for macOS, iOS, watchOS, tvOS.
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  // The value is ABI.  Value verified to be correct for OS X, iOS, watchOS, tvOS.
   return Semaphore(bitPattern: -1)
-#elseif canImport(Glibc)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   // The value is ABI.  Value verified to be correct on Glibc.
   return Semaphore(bitPattern: 0)
 #else
@@ -429,7 +429,7 @@ public func sem_open(
 //===----------------------------------------------------------------------===//
 
 // Some platforms don't have `extern char** environ` imported from C.
-#if canImport(Darwin) || os(FreeBSD) || os(OpenBSD) || os(PS4)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(OpenBSD) || os(PS4)
 public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
   return _swift_stdlib_getEnviron()
 }

--- a/stdlib/public/Platform/TiocConstants.swift
+++ b/stdlib/public/Platform/TiocConstants.swift
@@ -13,7 +13,7 @@
 // Tty ioctl request constants, needed only on Darwin and FreeBSD.
 
 // Constants available on all platforms, also available on Linux.
-#if canImport(Darwin) || os(FreeBSD) || os(Haiku)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(FreeBSD) || os(Haiku)
 
 /// Set exclusive use of tty.
 public var TIOCEXCL: UInt { return 0x2000740d }
@@ -115,7 +115,7 @@ public var TIOCGLTC: UInt { return 0x40067474 }
 
 
 // Darwin only constants, also available on Linux.
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
 /// Get termios struct.
 public var TIOCGETA: UInt { return 0x40487413 }

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -234,7 +234,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 
 % end
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 // Unary intrinsic functions
 // Note these have a corresponding LLVM intrinsic
 % for T, ufunc in TypedUnaryIntrinsicFunctions():

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -24,7 +24,7 @@ public func _stdlib_isOSVersionAtLeast(
   _ minor: Builtin.Word,
   _ patch: Builtin.Word
 ) -> Builtin.Int1 {
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   if Int(major) == 9999 {
     return true._value
   }

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -67,7 +67,7 @@ public typealias CFloat = Float
 public typealias CDouble = Double
 
 /// The C 'long double' type.
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 #if arch(x86_64) || arch(i386)
 public typealias CLongDouble = Float80
@@ -231,7 +231,7 @@ extension UInt {
 }
 
 /// A wrapper around a C `va_list` pointer.
-#if arch(arm64) && !(canImport(Darwin) || os(Windows))
+#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 @frozen
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -454,18 +454,12 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   internal var isImmutable: Bool {
     get {
-// TODO: Enable COW runtime checks by default (when INTERNAL_CHECKS_ENABLED
-//       is set). Currently there is a problem with remote AST which needs to be
-//       fixed.
-#if ENABLE_COW_RUNTIME_CHECKS
       if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
         return capacity == 0 || _swift_isImmutableCOWBuffer(_storage)
       }
-#endif
       return true
     }
     nonmutating set {
-#if ENABLE_COW_RUNTIME_CHECKS
       if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
         if newValue {
           if capacity > 0 {
@@ -481,17 +475,14 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
             "re-setting mutable array buffer to mutable")
         }
       }
-#endif
     }
   }
   
   @_alwaysEmitIntoClient
   internal var isMutable: Bool {
-#if ENABLE_COW_RUNTIME_CHECKS
     if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
       return !_swift_isImmutableCOWBuffer(_storage)
     }
-#endif
     return true
   }
 #endif

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -590,7 +590,7 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_NFKC_CASEFOLDED)
   }
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   // FIXME: These properties were introduced in ICU 57, but Ubuntu 16.04 comes
   // with ICU 55 so the values won't be correct there. Exclude them on
   // non-Darwin platforms for now; bundling ICU with the toolchain would resolve

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -91,7 +91,7 @@ internal let _countGPRegisters = 16
 @usableFromInline
 internal let _registerSaveWords = _countGPRegisters
 
-#elseif arch(arm64) && !(canImport(Darwin) || os(Windows))
+#elseif arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 // ARM Procedure Call Standard for aarch64. (IHI0055B)
 // The va_list type may refer to any parameter in a parameter list may be in one
 // of three memory locations depending on its type and position in the argument
@@ -419,7 +419,7 @@ extension Float80: CVarArg, _CVarArgAligned {
 }
 #endif
 
-#if (arch(x86_64) && !os(Windows)) || arch(s390x) || (arch(arm64) && !(canImport(Darwin) || os(Windows)))
+#if (arch(x86_64) && !os(Windows)) || arch(s390x) || (arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows)))
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1183,13 +1183,6 @@ swift_dynamicCastMetatypeImpl(const Metadata *sourceType,
     }
     break;
 
-  case MetadataKind::Existential: {
-    auto targetTypeAsExistential = static_cast<const ExistentialTypeMetadata *>(targetType);
-    if (_conformsToProtocols(nullptr, sourceType, targetTypeAsExistential, nullptr))
-      return origSourceType;
-    return nullptr;
-  }
-
   default:
     return nullptr;
   }

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -901,6 +901,7 @@ WeakReference *swift::swift_weakTakeAssign(WeakReference *dest,
 /// Returns true if the "immutable" flag is set on \p object.
 ///
 /// Used for runtime consistency checking of COW buffers.
+SWIFT_CC(swift)
 SWIFT_RUNTIME_EXPORT
 bool _swift_isImmutableCOWBuffer(HeapObject *object) {
   return object->refCounts.isImmutableCOWBuffer();
@@ -910,6 +911,7 @@ bool _swift_isImmutableCOWBuffer(HeapObject *object) {
 /// value of the flag.
 ///
 /// Used for runtime consistency checking of COW buffers.
+SWIFT_CC(swift)
 SWIFT_RUNTIME_EXPORT
 bool _swift_setImmutableCOWBuffer(HeapObject *object, bool immutable) {
   return object->refCounts.setIsImmutableCOWBuffer(immutable);

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -51,9 +51,9 @@ f0(i, i, // expected-error@:7 {{cannot convert value of type 'Int' to expected a
 
 
 // Cannot conform to protocols.
-f5(f4)  // expected-error {{type '(Int) -> Int' cannot conform to 'P2'; only struct/enum/class types can conform to protocols}}
-f5((1, "hello"))  // expected-error {{type '(Int, String)' cannot conform to 'P2'; only struct/enum/class types can conform to protocols}}
-f5(Int.self) // expected-error {{type 'Int.Type' cannot conform to 'P2'; only struct/enum/class types can conform to protocols}}
+f5(f4)  // expected-error {{type '(Int) -> Int' cannot conform to 'P2'; only concrete types such as structs, enums and classes can conform to protocols}}
+f5((1, "hello"))  // expected-error {{type '(Int, String)' cannot conform to 'P2'; only concrete types such as structs, enums and classes can conform to protocols}}
+f5(Int.self) // expected-error {{type 'Int.Type' cannot conform to 'P2'; only concrete types such as structs, enums and classes can conform to protocols}}
 
 // Tuple element not convertible.
 f0(i,
@@ -104,7 +104,7 @@ func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {}  // expected-note {{where 'T' 
 f8(3, f4) // expected-error {{global function 'f8' requires that 'Int' conform to 'P2'}}
 typealias Tup = (Int, Double)
 func f9(_ x: Tup) -> Tup { return x }
-f8((1,2.0), f9) // expected-error {{type 'Tup' (aka '(Int, Double)') cannot conform to 'P2'; only struct/enum/class types can conform to protocols}}
+f8((1,2.0), f9) // expected-error {{type 'Tup' (aka '(Int, Double)') cannot conform to 'P2'; only concrete types such as structs, enums and classes can conform to protocols}}
 
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -179,7 +179,7 @@ struct Label<L> : P where L : P { // expected-note 2 {{'L' declared as parameter
 }
 
 func test_51167632() -> some P {
-  AnyP(G { // expected-error {{type 'Label<_>.Type' cannot conform to 'P'; only struct/enum/class types can conform to protocols}}
+  AnyP(G { // expected-error {{type 'Label<_>.Type' cannot conform to 'P'; only concrete types such as structs, enums and classes can conform to protocols}}
     Text("hello")
     Label  // expected-error {{generic parameter 'L' could not be inferred}}
     // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{10-10=<<#L: P#>>}}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -188,7 +188,7 @@ func r22459135() {
 
 // <rdar://problem/19710848> QoI: Friendlier error message for "[] as Set"
 // <rdar://problem/22326930> QoI: "argument for generic parameter 'Element' could not be inferred" lacks context
-_ = [] as Set  // expected-error {{value of protocol type 'Any' cannot conform to 'Hashable'; only struct/enum/class types can conform to protocols}}
+_ = [] as Set  // expected-error {{protocol 'Any' as a type cannot conform to 'Hashable'; only concrete types such as structs, enums and classes can conform to protocols}}
 // expected-note@-1 {{required by generic struct 'Set' where 'Element' = 'Any'}}
 
 

--- a/test/Constraints/rdar64890308.swift
+++ b/test/Constraints/rdar64890308.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib
+
+// rdar://64890308: Make sure we don't leave one-way constraints unsolved.
+
+import Swift
+
+@_functionBuilder
+class ArrayBuilder<Element> {
+  static func buildBlock() -> [Element] { [] }
+  static func buildBlock(_ elt: Element) -> [Element] { [elt] }
+  static func buildBlock(_ elts: Element...) -> [Element] { elts }
+}
+
+func foo<T>(@ArrayBuilder<T> fn: () -> [T]) {}
+
+// FIXME(SR-13132): This should compile.
+foo { // expected-error {{type of expression is ambiguous without more context}}
+  ""
+}
+
+struct S<T> {
+  init(_: T.Type) {}
+  func overloaded() -> [T] { [] }
+  func overloaded(_ x: T) -> [T] { [x] }
+  func overloaded(_ x: T...) -> [T] { x }
+}
+
+func bar<T>(_ x: T, _ fn: (T, T.Type) -> [T]) {}
+bar("") { x, ty in
+  (Builtin.one_way(S(ty).overloaded(x)))
+}

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -128,9 +128,9 @@ func combined() {
 
     // Needs self conforming protocols:
     let _: Conforms = [[0: [1 : [works]] as Conforms]]
-    // expected-error@-1 {{value of protocol type 'Conforms' cannot conform to 'Conforms'; only struct/enum/class types can conform to protocols}}
+    // expected-error@-1 {{protocol 'Conforms' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
 
     let _: Conforms = [[0: [1 : [fails]] as Conforms]]
     // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
-    // expected-error@-2 {{value of protocol type 'Conforms' cannot conform to 'Conforms'; only struct/enum/class types can conform to protocols}}
+    // expected-error@-2 {{protocol 'Conforms' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/test/Generics/existential_restrictions.swift
+++ b/test/Generics/existential_restrictions.swift
@@ -23,7 +23,7 @@ func fAOE(_ t: AnyObject) { }
 func fT<T>(_ t: T) { }
 
 func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, ao: AnyObject) {
-  fP(p) // expected-error{{value of protocol type 'P' cannot conform to 'P'; only struct/enum/class types can conform to protocols}}
+  fP(p) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
   fAO(p) // expected-error{{global function 'fAO' requires that 'P' be a class type}}
   fAOE(p) // expected-error{{argument type 'P' expected to be an instance of a class or class-constrained type}}
   fT(p)
@@ -37,8 +37,8 @@ func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, 
   fAOE(cp)
   fT(cp)
 
-  fP(opp) // expected-error{{value of protocol type 'OP & P' cannot conform to 'P'; only struct/enum/class types can conform to protocols}}
-  fOP(opp) // expected-error{{value of protocol type 'OP & P' cannot conform to 'OP'; only struct/enum/class types can conform to protocols}}
+  fP(opp) // expected-error{{protocol 'OP & P' as a type cannot conform to 'P'; only concrete types such as structs, enums and classes can conform to protocols}}
+  fOP(opp) // expected-error{{protocol 'OP & P' as a type cannot conform to 'OP'; only concrete types such as structs, enums and classes can conform to protocols}}
   fAO(opp) // expected-error{{global function 'fAO' requires that 'OP & P' be a class type}}
   fAOE(opp)
   fT(opp)
@@ -64,9 +64,9 @@ class GAO<T : AnyObject> {} // expected-note 2{{requirement specified as 'T' : '
 func blackHole(_ t: Any) {}
 
 func testBindExistential() {
-  blackHole(GP<P>()) // expected-error{{value of protocol type 'P' cannot conform to 'P'; only struct/enum/class types can conform to protocols}}
+  blackHole(GP<P>()) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
   blackHole(GOP<OP>())
-  blackHole(GCP<CP>()) // expected-error{{value of protocol type 'CP' cannot conform to 'CP'; only struct/enum/class types can conform to protocols}}
+  blackHole(GCP<CP>()) // expected-error{{protocol 'CP' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
   blackHole(GAO<P>()) // expected-error{{'GAO' requires that 'P' be a class type}}
   blackHole(GAO<OP>())
   blackHole(GAO<CP>()) // expected-error{{'GAO' requires that 'CP' be a class type}}
@@ -92,5 +92,5 @@ func foo() {
   // generic no overloads error path. The error should actually talk
   // about the return type, and this can happen in other contexts as well;
   // <rdar://problem/21900971> tracks improving QoI here.
-  allMine.takeAll() // expected-error{{value of protocol type 'Mine' cannot conform to 'Mine'; only struct/enum/class types can conform to protocols}}
+  allMine.takeAll() // expected-error{{protocol 'Mine' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/test/IRGen/osx-targets.swift
+++ b/test/IRGen/osx-targets.swift
@@ -1,6 +1,8 @@
 // RUN: %swift %s -emit-ir | %FileCheck %s
 // RUN: %swift -target x86_64-apple-macosx10.51 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
-// RUN: %swift -target x86_64-apple-darwin55 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
+
+// disable this test until macOS 11 support lands in Swift.
+// : %swift -target x86_64-apple-darwin55 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
 
 // REQUIRES: OS=macosx
 

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -21,3 +21,7 @@ module MemberVariables {
 module ProtocolConformance {
   header "protocol-conformance.h"
 }
+
+module SynthesizedInitializers {
+  header "synthesized-initializers.h"
+}

--- a/test/Interop/Cxx/class/Inputs/synthesized-initializers.h
+++ b/test/Interop/Cxx/class/Inputs/synthesized-initializers.h
@@ -1,0 +1,5 @@
+struct EmptyStruct {};
+
+struct IntBox {
+  int x;
+};

--- a/test/Interop/Cxx/class/synthesized-initializers.swift
+++ b/test/Interop/Cxx/class/synthesized-initializers.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-silgen %s | %FileCheck %s
+
+import SynthesizedInitializers
+
+// CHECK-LABEL: sil shared [transparent] [serializable] [ossa] @$sSo11EmptyStructVABycfC : $@convention(method) (@thin EmptyStruct.Type) -> EmptyStruct
+// CHECK: bb0(%{{[0-9]+}} : $@thin EmptyStruct.Type):
+// CHECK-NEXT: [[BOX:%.*]] = alloc_box ${ var EmptyStruct }
+// CHECK-NEXT: [[UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]] : ${ var EmptyStruct }
+// CHECK-NEXT: [[PTR:%.*]] = project_box [[UNINIT]] : ${ var EmptyStruct }, 0
+// CHECK-NEXT: [[OBJ:%.*]] = builtin "zeroInitializer"<EmptyStruct>() : $EmptyStruct
+// CHECK-NEXT: [[PA:%.*]] = begin_access [modify] [unknown] [[PTR]] : $*EmptyStruct
+// CHECK-NEXT: assign [[OBJ]] to [[PA]]
+// CHECK-NEXT: end_access [[PA]]
+// CHECK-NEXT: [[OUT:%.*]] = load [trivial] [[PTR]]
+// CHECK-NEXT: destroy_value [[UNINIT]]
+// CHECK-NEXT: return [[OUT]]
+// CHECK-LABEL: end sil function '$sSo11EmptyStructVABycfC'
+public func emptyTypeNoArgInit() {
+  let e = EmptyStruct()
+}
+
+// CHECK-LABEL: sil shared [transparent] [serializable] [ossa] @$sSo6IntBoxVABycfC : $@convention(method) (@thin IntBox.Type) -> IntBox
+// CHECK: bb0(%{{[0-9]+}} : $@thin IntBox.Type):
+// CHECK-NEXT: [[BOX:%.*]] = alloc_box ${ var IntBox }
+// CHECK-NEXT: [[UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]] : ${ var IntBox }
+// CHECK-NEXT: [[PTR:%.*]] = project_box [[UNINIT]] : ${ var IntBox }, 0
+// CHECK-NEXT: [[OBJ:%.*]] = builtin "zeroInitializer"<IntBox>() : $IntBox
+// CHECK-NEXT: [[PA:%.*]] = begin_access [modify] [unknown] [[PTR]] : $*IntBox
+// CHECK-NEXT: assign [[OBJ]] to [[PA]]
+// CHECK-NEXT: end_access [[PA]]
+// CHECK-NEXT: [[OUT:%.*]] = load [trivial] [[PTR]]
+// CHECK-NEXT: destroy_value [[UNINIT]]
+// CHECK-NEXT: return [[OUT]]
+// CHECK-LABEL: end sil function '$sSo6IntBoxVABycfC'
+public func singleMemberTypeNoArgInit() {
+  let i = IntBox()
+}
+
+// CHECK-LABEL: sil shared [transparent] [serializable] [ossa] @$sSo6IntBoxV1xABs5Int32V_tcfC : $@convention(method) (Int32, @thin IntBox.Type) -> IntBox
+// CHECK: bb0([[I:%[0-9]+]] : $Int32, %{{[0-9]+}} : $@thin IntBox.Type):
+// CHECK-NEXT: [[S:%.*]] = struct $IntBox ([[I]] : $Int32)
+// CHECK-NEXT: return [[S]]
+// CHECK-LABEL: end sil function '$sSo6IntBoxV1xABs5Int32V_tcfC'
+public func singleMemberTypeValueInit() {
+  let i = IntBox(x: 42)
+}

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -1,0 +1,9 @@
+#ifndef TEST_INTEROP_CXX_OPERATORS_INPUTS_MEMBER_INLINE_H
+#define TEST_INTEROP_CXX_OPERATORS_INPUTS_MEMBER_INLINE_H
+
+struct IntBox {
+  int value;
+  IntBox operator+(IntBox rhs) { return IntBox{.value = value + rhs.value}; }
+};
+
+#endif

--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -1,3 +1,7 @@
+module MemberInline {
+  header "member-inline.h"
+}
+
 module NonMemberInline {
   header "non-member-inline.h"
 }

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+//
+// We can't yet call member functions correctly on Windows (SR-13129).
+// XFAIL: OS=windows-msvc
+
+import MemberInline
+
+public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+
+// CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN6IntBoxplES_|"\?\?HIntBox@@QEAA\?AU0@U0@@Z")]](%struct.IntBox* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval align 4}} {{%[0-9]+}})
+// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.IntBox* %this, {{i32 %rhs.coerce|\[1 x i32\] %rhs.coerce|i64 %rhs.coerce|%struct.IntBox\* byval\(%struct.IntBox\) align 4 %rhs}})

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct IntBox {
+// CHECK:   static func + (lhs: inout IntBox, rhs: IntBox) -> IntBox
+// CHECK: }

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import MemberInline
+
+public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+
+// CHECK: bb0([[SELF:%.*]] : $*IntBox, [[RHS:%.*]] : $IntBox):
+
+// CHECK: [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*IntBox
+// CHECK: [[OP:%.*]] = function_ref [[NAME:@(_ZN6IntBoxplES_|\?\?HIntBox@@QEAA\?AU0@U0@@Z)]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK: apply [[OP]]([[SELFACCESS]], [[RHS]]) : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK: end_access [[SELFACCESS]] : $*IntBox
+
+// CHECK: sil [clang IntBox."+"] [[NAME]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import MemberInline
+
+var lhs = IntBox(value: 42)
+let rhs = IntBox(value: 23)
+
+let resultPlus = lhs + rhs

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -1,0 +1,22 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+//
+// We can't yet call member functions correctly on Windows (SR-13129).
+// XFAIL: OS=windows-msvc
+
+import MemberInline
+import StdlibUnittest
+
+var OperatorsTestSuite = TestSuite("Operators")
+
+OperatorsTestSuite.test("plus") {
+  var lhs = IntBox(value: 42)
+  let rhs = IntBox(value: 23)
+
+  let result = lhs + rhs
+
+  expectEqual(65, result.value)
+}
+
+runAllTests()

--- a/test/Interpreter/generic_casts_objc.swift
+++ b/test/Interpreter/generic_casts_objc.swift
@@ -16,8 +16,11 @@ enum PE: P {}
 class PC: P, PObjC {}
 class PCSub: PC {}
 
-func nongenericAnyIsPObjC(type: Any.Type) -> Bool {
+func nongenericAnyIsPObjCType(type: Any.Type) -> Bool {
   return type is PObjC.Type
+}
+func nongenericAnyIsPObjCProtocol(type: Any.Type) -> Bool {
+  return type is PObjC.Protocol
 }
 func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   // If we're testing against a runtime that doesn't have the fix this tests,
@@ -29,13 +32,23 @@ func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   }
 }
 
-// CHECK-LABEL: casting types to ObjC protocols with generics:
-print("casting types to ObjC protocols with generics:")
-print(nongenericAnyIsPObjC(type: PS.self)) // CHECK: false
-print(genericAnyIs(type: PS.self, to: PObjC.self, expected: false)) // CHECK: false
-print(nongenericAnyIsPObjC(type: PE.self)) // CHECK: false
-print(genericAnyIs(type: PE.self, to: PObjC.self, expected: false)) // CHECK: false
-print(nongenericAnyIsPObjC(type: PC.self)) // CHECK: true
-print(genericAnyIs(type: PC.self, to: PObjC.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyIsPObjC(type: PCSub.self)) // CHECK: true
-print(genericAnyIs(type: PCSub.self, to: PObjC.self, expected: true)) // CHECK-ONONE: true
+// CHECK-LABEL: casting types to ObjC protocol existential metatype:
+print("casting types to ObjC protocol existential metatype:")
+print(#line, nongenericAnyIsPObjCType(type: PS.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCType(type: PE.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCType(type: PC.self)) // CHECK: [[@LINE]] true
+print(#line, nongenericAnyIsPObjCType(type: PCSub.self)) // CHECK: [[@LINE]] true
+
+// CHECK-LABEL: casting types to ObjC protocol metatype:
+print("casting types to ObjC protocol metatype:")
+print(#line, nongenericAnyIsPObjCProtocol(type: PS.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCProtocol(type: PE.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCProtocol(type: PC.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCProtocol(type: PCSub.self)) // CHECK: [[@LINE]] false
+
+// CHECK-LABEL: casting types to ObjC protocol metatype via generic:
+print("casting types to ObjC protocol metatype via generic:")
+print(#line, genericAnyIs(type: PS.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false
+print(#line, genericAnyIs(type: PE.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false
+print(#line, genericAnyIs(type: PC.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false
+print(#line, genericAnyIs(type: PCSub.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -143,7 +143,7 @@ func test17875634() {
 func test20770032() {
   if case let 1...10 = (1, 1) { // expected-warning{{'let' pattern has no effect; sub-pattern didn't bind any variables}} {{11-15=}}
     // expected-error@-1 {{expression pattern of type 'ClosedRange<Int>' cannot match values of type '(Int, Int)'}}
-    // expected-error@-2 {{'(Int, Int)' cannot conform to 'Equatable'; only struct/enum/class types can conform to protocols}}
+    // expected-error@-2 {{type '(Int, Int)' cannot conform to 'Equatable'; only concrete types such as structs, enums and classes can conform to protocols}}
     // expected-note@-3 {{required by operator function '~=' where 'T' = '(Int, Int)'}}
   }
 }

--- a/test/Parse/confusables.swift
+++ b/test/Parse/confusables.swift
@@ -17,7 +17,7 @@ if (true ꝸꝸꝸ false) {} // expected-note {{identifier 'ꝸꝸꝸ' contains 
 
 // expected-error @+3 {{invalid character in source file}}
 // expected-error @+2 {{expected ',' separator}}
-// expected-error @+1 {{type '(Int, Int)' cannot conform to 'BinaryInteger'; only struct/enum/class types can conform to protocols}}
+// expected-error @+1 {{type '(Int, Int)' cannot conform to 'BinaryInteger'; only concrete types such as structs, enums and classes can conform to protocols}}
 if (5 ‒ 5) == 0 {} // expected-note {{unicode character '‒' looks similar to '-'; did you mean to use '-'?}} {{7-10=-}}
 // expected-note @-1 {{operator function '=='}}
 

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 4 -o %t/a.out %s
+// RUN: not --crash %target-build-swift -swift-version 4 -o %t/a.out %s
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: CPU=x86_64

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -486,9 +486,7 @@ func test_variadics() {
   // CHECK: [[FN_REF:%[0-9]+]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK: [[MAKE_ARR:%[0-9]+]] = apply [[FN_REF]]<Int>([[ARR_COUNT]])
   // CHECK: ([[ARR:%[0-9]+]], %{{[0-9]+}}) = destructure_tuple [[MAKE_ARR]] : $(Array<Int>, Builtin.RawPointer)
-  // CHECK: [[FIN_REF:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK: [[FIN_ARR:%[0-9]+]] = apply [[FIN_REF]]<Int>([[ARR]])
-  // CHECK: keypath $KeyPath<SubscriptVariadic1, Int>, (root $SubscriptVariadic1; gettable_property $Int,  id @$s8keypaths18SubscriptVariadic1VyS2id_tcig : $@convention(method) (@guaranteed Array<Int>, SubscriptVariadic1) -> Int, getter @$s8keypaths18SubscriptVariadic1VyS2id_tcipACTK : $@convention(thin) (@in_guaranteed SubscriptVariadic1, UnsafeRawPointer) -> @out Int, indices [%$0 : $Array<Int> : $Array<Int>], indices_equals @$sSaySiGTH : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @$sSaySiGTh : $@convention(thin) (UnsafeRawPointer) -> Int) ([[FIN_ARR]])
+  // CHECK: keypath $KeyPath<SubscriptVariadic1, Int>, (root $SubscriptVariadic1; gettable_property $Int,  id @$s8keypaths18SubscriptVariadic1VyS2id_tcig : $@convention(method) (@guaranteed Array<Int>, SubscriptVariadic1) -> Int, getter @$s8keypaths18SubscriptVariadic1VyS2id_tcipACTK : $@convention(thin) (@in_guaranteed SubscriptVariadic1, UnsafeRawPointer) -> @out Int, indices [%$0 : $Array<Int> : $Array<Int>], indices_equals @$sSaySiGTH : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @$sSaySiGTh : $@convention(thin) (UnsafeRawPointer) -> Int) ([[ARR]])
   _ = \SubscriptVariadic1.[]
   
   _ = \SubscriptVariadic2.["", "1"]

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -68,8 +68,6 @@ variadicFirst(x)
 // CHECK: [[X:%.*]] = load [trivial] [[READ]]
 // CHECK: [[ALLOC_ARRAY:%.*]] = apply {{.*}} -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: ([[ARRAY:%.*]], [[MEMORY:%.*]]) = destructure_tuple [[ALLOC_ARRAY]]
-// CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-// CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Int>([[ARRAY]])
 // CHECK: [[VARIADIC_SECOND:%.*]] = function_ref @$s20scalar_to_tuple_args14variadicSecondyySi_SidtF
-// CHECK: apply [[VARIADIC_SECOND]]([[X]], [[FIN_ARR]])
+// CHECK: apply [[VARIADIC_SECOND]]([[X]], [[ARRAY]])
 variadicSecond(x)

--- a/test/SILOptimizer/Inputs/struct_with_fields.swift
+++ b/test/SILOptimizer/Inputs/struct_with_fields.swift
@@ -1,0 +1,5 @@
+
+public struct TestStruct {
+  public var x: Int
+  public var y: Int
+}

--- a/test/SILOptimizer/keypath_offset.swift
+++ b/test/SILOptimizer/keypath_offset.swift
@@ -1,0 +1,197 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift %S/Inputs/struct_with_fields.swift -parse-as-library -wmo -enable-library-evolution -module-name=Test -emit-module -emit-module-path=%t/Test.swiftmodule -c -o %t/test.o
+
+// RUN: %target-build-swift -O %s -module-name=test -Xfrontend -sil-verify-all -I%t -emit-sil | %FileCheck %s
+
+// RUN: %target-build-swift -Onone %s -I%t %t/test.o -o %t/Onone.out
+// RUN: %target-build-swift -O %s -I%t %t/test.o -o %t/O.out
+// RUN: %target-run %t/Onone.out > %t/Onone.txt
+// RUN: %target-run %t/O.out > %t/O.txt
+// RUN: diff  %t/Onone.txt %t/O.txt
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+
+import Test
+
+final class C<T> {
+  var x: Int
+  var z: T
+  let immutable: String
+  private(set) var secretlyMutable: String
+
+  init(x: Int, z: T) {
+    self.x = x
+    self.z = z
+    self.immutable = "somestring"
+    self.secretlyMutable = immutable
+  }
+}
+
+struct Point {
+  var x: Double
+  var y: Double
+}
+
+struct S<T> {
+  var x: Int
+  var y: Int?
+  var z: T
+  var p: Point
+  var op: Point?
+  var c: C<T>
+}
+
+struct NonOffsetableProperties {
+  // observers
+  var x: Int { didSet {} }
+  // reabstracted
+  var y: () -> ()
+  // computed
+  var z: Int { return 0 }
+}
+
+struct TupleProperties {
+  // unlabeled
+  var a: (Int, String)
+  // labeled
+  let b: (x: String, y: Int)
+  // reference writable
+  let c: (m: C<Int>, n: C<String>)
+}
+
+typealias Tuple<T, U> = (S<T>, C<U>)
+
+func getIdentityKeyPathOfType<T>(_: T.Type) -> KeyPath<T, T> {
+  return \.self
+}
+
+
+@inline(never)
+func printOffset(_ o: Int?) {
+  print(o as Any)
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A13StructOffsetsyyF
+// CHECK-NOT:     _storedInlineOffset
+// CHECK-NOT:     class_method
+// CHECK:       } // end sil function '$s4test0A13StructOffsetsyyF'
+@inline(never)
+func testStructOffsets() {
+  let SLayout = MemoryLayout<S<Int>>.self
+  printOffset(SLayout.offset(of: \S<Int>.x))
+  printOffset(SLayout.offset(of: \S<Int>.y))
+  printOffset(SLayout.offset(of: \S<Int>.z))
+  printOffset(SLayout.offset(of: \S<Int>.p))
+  printOffset(SLayout.offset(of: \S<Int>.p.x))
+  printOffset(SLayout.offset(of: \S<Int>.p.y))
+  printOffset(SLayout.offset(of: \S<Int>.c))
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A20GenericStructOffsetsyyxmlF
+// CHECK-NOT:     _storedInlineOffset
+// CHECK-NOT:     class_method
+// CHECK:       } // end sil function '$s4test0A20GenericStructOffsetsyyxmlF'
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenericStructOffsets<T>(_ t: T.Type) {
+  let SLayout = MemoryLayout<S<T>>.self
+  printOffset(SLayout.offset(of: \S<T>.x))
+  printOffset(SLayout.offset(of: \S<T>.y))
+  printOffset(SLayout.offset(of: \S<T>.z))
+  printOffset(SLayout.offset(of: \S<T>.p))
+  printOffset(SLayout.offset(of: \S<T>.p.x))
+  printOffset(SLayout.offset(of: \S<T>.p.y))
+  printOffset(SLayout.offset(of: \S<T>.c))
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A10NonOffsetsyyF
+// CHECK-NOT:     _storedInlineOffset
+// CHECK-NOT:     class_method
+// CHECK:       } // end sil function '$s4test0A10NonOffsetsyyF'
+@inline(never)
+func testNonOffsets() {
+  let NOPLayout = MemoryLayout<NonOffsetableProperties>.self
+  printOffset(NOPLayout.offset(of: \NonOffsetableProperties.x))
+  printOffset(NOPLayout.offset(of: \NonOffsetableProperties.y))
+  printOffset(NOPLayout.offset(of: \NonOffsetableProperties.z))
+  printOffset(MemoryLayout<C<Int>>.offset(of: \C<Int>.x))
+  let SLayout = MemoryLayout<S<Int>>.self
+  printOffset(SLayout.offset(of: \S<Int>.c.x))
+  printOffset(SLayout.offset(of: \S<Int>.op!.x))
+  printOffset(SLayout.offset(of: \S<Int>.op?.x))
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A11SelfOffsetsyyF
+// CHECK-NOT:     _storedInlineOffset
+// CHECK-NOT:     class_method
+// CHECK:       } // end sil function '$s4test0A11SelfOffsetsyyF'
+@inline(never)
+func testSelfOffsets() {
+  let SLayout = MemoryLayout<S<Int>>.self
+  printOffset(SLayout.offset(of: \.self))
+  printOffset(SLayout.offset(of: getIdentityKeyPathOfType(S<Int>.self)))
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A12TupleOffsetsyyF
+// CHECK-NOT:     _storedInlineOffset
+// CHECK-NOT:     class_method
+// CHECK:       } // end sil function '$s4test0A12TupleOffsetsyyF'
+@inline(never)
+func testTupleOffsets() {
+  let TPLayout = MemoryLayout<TupleProperties>.self
+  printOffset(TPLayout.offset(of: \TupleProperties.self))
+  printOffset(TPLayout.offset(of: \TupleProperties.a))
+  printOffset(TPLayout.offset(of: \TupleProperties.a.0))
+  printOffset(TPLayout.offset(of: \TupleProperties.a.1))
+  printOffset(TPLayout.offset(of: \TupleProperties.b))
+  printOffset(TPLayout.offset(of: \TupleProperties.b.x))
+  printOffset(TPLayout.offset(of: \TupleProperties.b.y))
+  printOffset(TPLayout.offset(of: \TupleProperties.c))
+  printOffset(TPLayout.offset(of: \TupleProperties.c.m))
+  printOffset(TPLayout.offset(of: \TupleProperties.c.n))
+
+  let TLayout = MemoryLayout<Tuple<Int, Int>>.self
+  printOffset(TLayout.offset(of: \Tuple<Int, Int>.self))
+  printOffset(TLayout.offset(of: \Tuple<Int, Int>.0))
+  printOffset(TLayout.offset(of: \Tuple<Int, Int>.0.x))
+  printOffset(TLayout.offset(of: \Tuple<Int, Int>.1))
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A19GenericTupleOffsetsyyxmlF
+// CHECK-NOT:     _storedInlineOffset
+// CHECK-NOT:     class_method
+// CHECK:       } // end sil function '$s4test0A19GenericTupleOffsetsyyxmlF'
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenericTupleOffsets<T>(_ t: T.Type) {
+  let TLayout = MemoryLayout<Tuple<T, T>>.self
+  printOffset(TLayout.offset(of: \Tuple<T, T>.self))
+  printOffset(TLayout.offset(of: \Tuple<T, T>.0))
+  printOffset(TLayout.offset(of: \Tuple<T, T>.0.x))
+  printOffset(TLayout.offset(of: \Tuple<T, T>.1))
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A16ResilientOffsetsyyF
+// CHECK:         class_method {{.*}}_storedInlineOffset
+// CHECK:       } // end sil function '$s4test0A16ResilientOffsetsyyF'
+@inline(never)
+func testResilientOffsets() {
+  let TLayout = MemoryLayout<TestStruct>.self
+  printOffset(TLayout.offset(of: \TestStruct.x))
+}
+
+print("### testStructOffsets")
+testStructOffsets()
+print("### testGenericStructOffsets")
+testGenericStructOffsets(Int.self)
+print("### testNonOffsets")
+testNonOffsets()
+print("### testSelfOffsets")
+testSelfOffsets()
+print("### testTupleOffsets")
+testTupleOffsets()
+print("### testGenericTupleOffsets")
+testGenericTupleOffsets(Int.self)
+print("### testResilientOffsets")
+testResilientOffsets()
+

--- a/test/decl/protocol/conforms/error_self_conformance.swift
+++ b/test/decl/protocol/conforms/error_self_conformance.swift
@@ -11,15 +11,15 @@ func testSimple(error: Error) {
 
 protocol ErrorRefinement : Error {}
 func testErrorRefinment(error: ErrorRefinement) {
-  wantsError(error) // expected-error {{value of protocol type 'ErrorRefinement' cannot conform to 'Error'; only struct/enum/class types can conform to protocols}}
+  wantsError(error) // expected-error {{protocol 'ErrorRefinement' as a type cannot conform to 'Error'; only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 protocol OtherProtocol {}
 func testErrorComposition(error: Error & OtherProtocol) {
-  wantsError(error) // expected-error {{value of protocol type 'Error & OtherProtocol' cannot conform to 'Error'; only struct/enum/class types can conform to protocols}}
+  wantsError(error) // expected-error {{protocol 'Error & OtherProtocol' as a type cannot conform to 'Error'; only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 class C {}
 func testErrorCompositionWithClass(error: Error & C) {
-  wantsError(error) // expected-error {{value of protocol type 'C & Error' cannot conform to 'Error'; only struct/enum/class types can conform to protocols}}
+  wantsError(error) // expected-error {{protocol 'C & Error' as a type cannot conform to 'Error'; only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -699,7 +699,7 @@ if (run_os == 'maccatalyst'):
   target_os_abi = 'macosx'
   target_os_is_maccatalyst = "TRUE"
   config.available_features.add("OS=ios")
-if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android', 'linux-androideabi']):
+if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android', 'linux-androideabi']):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')
 config.substitutions.append(('%target-os-abi', target_os_abi))
@@ -1590,7 +1590,7 @@ source_compiler_rt_libs(compiler_rt_dir)
 
 def check_runtime_libs(features_to_check):
     for lib in config.compiler_rt_libs:
-        for (libname, feature) in features_to_check.iteritems():
+        for (libname, feature) in features_to_check.items():
             if lib.startswith("libclang_rt." + libname + "_"):
                 config.available_features.add(feature)
 

--- a/test/stdlib/Casts.swift
+++ b/test/stdlib/Casts.swift
@@ -21,6 +21,8 @@ import StdlibUnittest
 import Foundation
 #endif
 
+private func blackhole<T>(_ t: T) {}
+
 let CastsTests = TestSuite("Casts")
 
 // Test for SR-426: missing release for some types after failed conversion
@@ -160,5 +162,64 @@ CastsTests.test("Dynamic casts of CF types to protocol existentials")
   }
 }
 #endif
+
+CastsTests.test("Any.Protocol") {
+  class C {}
+  struct S {}
+  func isAnyProtocol<T>(_ type: T.Type) -> Bool {
+    let result = T.self is Any.Protocol
+		if result {
+			// `as!` should succeed if `is` does
+			blackhole(T.self as! Any.Protocol)
+		}
+    return result
+  }
+  func isAnyType<T>(_ type: T.Type) -> Bool {
+    return T.self is Any.Type
+  }
+  func isType<T,U>(_ type: T.Type, to: U.Type) -> Bool {
+    return T.self is U.Type
+  }
+
+  expectTrue(Int.self is Any.Type)
+  expectNotNil(Int.self as? Any.Type)
+  expectTrue(isAnyType(Int.self))
+  expectFalse(Int.self is Any.Protocol)
+  expectNil(Int.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(Int.self))
+  expectFalse(isType(Int.self, to: Any.self))
+
+  expectTrue(C.self is Any.Type)
+  expectNotNil(C.self as? Any.Type)
+  expectTrue(isAnyType(C.self))
+  expectFalse(C.self is Any.Protocol)
+  expectNil(C.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(C.self))
+  expectFalse(isType(C.self, to: Any.self))
+
+  expectTrue(S.self is Any.Type)
+  expectNotNil(S.self as? Any.Type)
+  expectTrue(isAnyType(S.self))
+  expectFalse(S.self is Any.Protocol)
+  expectNil(S.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(S.self))
+  expectFalse(isType(S.self, to: Any.self))
+
+  expectTrue(Any.self is Any.Type)
+  expectNotNil(Any.self as? Any.Type)
+  expectTrue(isAnyType(Any.self))
+  expectTrue(Any.self is Any.Protocol)
+  expectNotNil(Any.self as? Any.Protocol)
+  expectTrue(isAnyProtocol(Any.self))
+  expectTrue(isType(Any.self, to: Any.self))
+
+  expectTrue(Any?.self is Any.Type)
+  expectNotNil(Any?.self as? Any.Type)
+  expectTrue(isAnyType(Any?.self))
+  expectFalse(Any?.self is Any.Protocol)
+  expectNil(Any?.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(Any?.self))
+  expectFalse(isType(Any?.self, to: Any.self))
+}
 
 runAllTests()

--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -30,6 +30,7 @@
 // RUN:             -e _ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEPA80_cEEEvv \
 // RUN:             -e _ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEPA88_cEEEvv \
 // RUN:             -e _ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEPA104_cEEEvv \
+// RUN:             -e _ZN9__gnu_cxx12__to_xstringISscEET_PFiPT0_mPKS2_P13__va_list_tagEmS5_z \
 // RUN:   > %t/swiftCore-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-no-weak.txt
 // RUN: diff -u %t/swiftCore-all.txt %t/swiftCore-no-weak.txt
@@ -51,6 +52,7 @@
 // RUN:             -e _ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEPA80_cEEEvv \
 // RUN:             -e _ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEPA88_cEEEvv \
 // RUN:             -e _ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEPA104_cEEEvv \
+// RUN:             -e _ZN9__gnu_cxx12__to_xstringISscEET_PFiPT0_mPKS2_P13__va_list_tagEmS5_z \
 // RUN:   > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt
 // RUN: diff -u %t/swiftRemoteMirror-all.txt %t/swiftRemoteMirror-no-weak.txt

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -177,7 +177,7 @@ func testOptionalSequence() {
 
 // Crash with (invalid) for each over an existential
 func testExistentialSequence(s: Sequence) { // expected-error {{protocol 'Sequence' can only be used as a generic constraint because it has Self or associated type requirements}}
-  for x in s { // expected-error {{value of protocol type 'Sequence' cannot conform to 'Sequence'; only struct/enum/class types can conform to protocols}}
+  for x in s { // expected-error {{protocol 'Sequence' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
     _ = x
   }
 }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -13,7 +13,7 @@ class C {}
 class D: C, P, Q { func paul() {}; func priscilla() {}; func quinn() {} }
 
 let property: some P = 1
-let deflessLet: some P // expected-error{{has no initializer}}
+let deflessLet: some P // expected-error{{has no initializer}} {{educational-notes=opaque-type-inference}}
 var deflessVar: some P // expected-error{{has no initializer}}
 
 struct GenericProperty<T: P> {
@@ -173,13 +173,13 @@ func recursion(x: Int) -> some P {
   return recursion(x: x - 1)
 }
 
-func noReturnStmts() -> some P {} // expected-error {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
+func noReturnStmts() -> some P {} // expected-error {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}} {{educational-notes=opaque-type-inference}}
 
 func returnUninhabited() -> some P { // expected-note {{opaque return type declared here}}
     fatalError() // expected-error{{return type of global function 'returnUninhabited()' requires that 'Never' conform to 'P'}}
 }
 
-func mismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> some P { // expected-error{{do not have matching underlying types}}
+func mismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> some P { // expected-error{{do not have matching underlying types}} {{educational-notes=opaque-type-inference}}
   if x {
     return y // expected-note{{underlying type 'Int'}}
   } else {
@@ -209,7 +209,7 @@ func jan() -> some P {
   return [marcia(), marcia(), marcia()]
 }
 func marcia() -> some P {
-  return [marcia(), marcia(), marcia()] // expected-error{{defines the opaque type in terms of itself}}
+  return [marcia(), marcia(), marcia()] // expected-error{{defines the opaque type in terms of itself}} {{educational-notes=opaque-type-inference}}
 }
 
 protocol R {
@@ -383,7 +383,7 @@ protocol P_51641323 {
 func rdar_51641323() {
   struct Foo: P_51641323 {
     var foo: some P_51641323 { // expected-note {{required by opaque return type of property 'foo'}}
-      {} // expected-error {{type '() -> ()' cannot conform to 'P_51641323'; only struct/enum/class types can conform to protocols}}
+      {} // expected-error {{type '() -> ()' cannot conform to 'P_51641323'; only concrete types such as structs, enums and classes can conform to protocols}}
     }
   }
 }

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -413,7 +413,7 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   // expected-error@-1 {{global function 'conformsToAnyObject' requires that 'P1' be a class type}}
 
   conformsToP1(p1)
-  // expected-error@-1 {{value of protocol type 'P1' cannot conform to 'P1'; only struct/enum/class types can conform to protocols}}
+  // expected-error@-1 {{protocol 'P1' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
 
   // FIXME: Following diagnostics are not great because when
   // `conformsTo*` methods are re-typechecked, they loose information

--- a/userdocs/diagnostics/opaque-type-inference.md
+++ b/userdocs/diagnostics/opaque-type-inference.md
@@ -1,0 +1,68 @@
+# Underlying Type Inference for Opaque Result Types
+
+Opaque result types are a useful tool for abstracting the return type of a function or subscript, or type of a property. Although the concrete underlying type of an opaque type is hidden from clients, it is still inferred by the compiler, which enforces certain usage requirements:
+
+- Property declarations with opaque types must have an initializer expression or getter, and functions or subscripts returning opaque types must have at least one `return` statement:
+
+```swift
+let x: some Equatable // error: property declares an opaque return type, but has no initializer expression from which to infer an underlying type
+let y: some Equatable = 42 // OK
+let z: some Equatable { // Also OK
+  return "hello, " + "world!"
+}
+
+func foo() -> some Equatable { // error: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
+  fatalError("Unimplemented")
+}
+
+func bar() -> some Equatable { // OK
+  fatalError("Unimplemented")
+  return 42
+}
+```
+
+- The underlying type of an opaque type must be unique. In other words, if a function or subscript returns an opaque type, it must return values of the same underlying type from every `return` statement in its body.
+
+```swift
+func foo(bar: Bool) -> some Equatable { // error: function declares an opaque return type, but the return statements in its body do not have matching underlying types
+  if bar {
+    return "hello, world!" // note: return statement has underlying type 'String'
+  } else {
+    return 1 // note: return statement has underlying type 'Int'
+  }
+}
+
+func bar(baz: Bool) -> some Equatable { // OK, both branches of the if statement return a value of the same underlying type, Int.
+  if baz {
+    return 100
+  } else {
+    return 200
+  }
+}
+```
+
+- Functions returning opaque types may be recursive. However, such functions must have at least one `return` statement that returns a concrete underlying type as opposed to the function's own opaque result type. Additionally, recursive calls may not be used to create an infinitely recursive opaque type.
+
+```swift
+func foo(_ x: Int) -> some Equatable { // error: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
+  // Not allowed because there aren't any non-recursive returns to infer the underlying type from.
+  return foo(x+1)
+}
+
+struct EquatableWrapper<T: Equatable>: Equatable { var value: T }
+func foo() -> some Equatable { // error: function opaque return type was inferred as 'EquatableWrapper<some Equatable>', which defines the opaque type in terms of itself
+  // Not allowed because the use of EquatableWrapper creates an infinitely recursive underlying type: EquatableWrapper<EquatableWrapper<EquatableWrapper<...>>>...>
+  return EquatableWrapper(value: foo())
+}
+
+func bar(_ x: Int) -> some Equatable { // OK, the underlying type can be inferred from the second return statement.
+  if x > 0 {
+    return bar(x-1)
+  } else {
+    return x
+  }
+}
+```
+
+To learn more about opaque result types, see the [Opaque Types](https://docs.swift.org/swift-book/LanguageGuide/OpaqueTypes.html) section of _The Swift Programming Language_.
+

--- a/userdocs/diagnostics/protocol-type-non-conformance.md
+++ b/userdocs/diagnostics/protocol-type-non-conformance.md
@@ -1,0 +1,46 @@
+# Protocol type not conforming to itself
+Protocols in Swift may be used as types. Protocols as types are sometimes called existential types.
+
+
+```swift 
+protocol P {}
+
+struct S: P {}
+
+var s: P = S() // This creates existential type because the protocol P is used as a type
+```
+
+However, a protocol type does not conform to protocols - not even the protocol itself. 
+Allowing existential types to conform to protocols is unsound. For protocols with static method, initializer, or associated type requirements, the implementation of these requirements cannot be accessed from the protocol type - accessing these kinds of requirements must be done using a concrete type.
+
+Let's walk through the example below:
+
+```swift
+protocol Word: Hashable {
+    var word: String { get }
+}
+
+struct Singular: Word {
+    var word: String
+}
+
+struct Plural: Word {
+    var word: String
+}
+
+let singularWord = Singular(word: "mango")
+let pluralWord = Plural(word: "mangoes")
+
+let wordPairDict: [Word: Word] = [singularWord: pluralWord] // Error
+```
+
+One workaround to fix this problem is to use type erasure for the protocol `Word`. Think of type erasure as a way to hide an object's type. Since `Word` is of type `Hashable`, we already have `AnyHashable` type erasure available in the standard library which we can easily use here.
+
+```swift 
+// The fix
+let wordPairDict: [AnyHashable: AnyHashable] = [singularWord: pluralWord]
+```
+
+# Exceptions
+`@objc` protocol type with no static requirements however do conform to its own protocol. Another exception is the `Error` Swift protocol.
+

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -67,20 +67,21 @@ constants.""")
 
     if args.enable_windows_compatibility:
         if args.enable_yaml_compatibility:
-            slashes_re = b'(/|\\\\\\\\|\\\\\\\\\\\\\\\\)'
+            slashes_re = r'(/|\\\\|\\\\\\\\)'
         else:
-            slashes_re = b'(/|\\\\\\\\)'
+            slashes_re = r'(/|\\\\)'
     else:
-        slashes_re = b'/'
+        slashes_re = r'/'
 
-    stdin = io.open(sys.stdin.fileno(), 'rb').read()
+    stdin = io.open(sys.stdin.fileno(), 'r', encoding='utf-8', errors='ignore').read()
 
     for s in args.sanitize_strings:
-        replacement, pattern = s.encode(encoding="utf-8").split(b'=', 1)
+        replacement, pattern = s.split('=', 1)
         # Since we want to use pattern as a regex in some platforms, we need
         # to escape it first, and then replace the escaped slash
         # literal (r'\\/') for our platform-dependent slash regex.
-        stdin = re.sub(re.sub(b'\\\\/', slashes_re, re.escape(pattern)),
+        stdin = re.sub(re.sub('\\\\/' if sys.version_info[0] < 3 else r'[/\\]',
+                              slashes_re, re.escape(pattern)),
                        replacement,
                        stdin)
 
@@ -90,7 +91,7 @@ constants.""")
     else:
         p = subprocess.Popen(
             [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)
-        stdout, stderr = p.communicate(stdin)
+        stdout, stderr = p.communicate(stdin.encode('utf-8'))
         if stdout is not None:
             print(stdout)
         if stderr is not None:

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from functools import reduce
 
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 
@@ -17,7 +18,8 @@ class RoundTripTask(object):
     def __init__(self, input_filename, action, swift_syntax_test,
                  skip_bad_syntax):
         assert action == '-round-trip-parse' or action == '-round-trip-lex'
-        assert type(input_filename) == unicode
+        if sys.version_info[0] < 3:
+            assert type(input_filename) == unicode
         assert type(swift_syntax_test) == str
 
         assert os.path.isfile(input_filename), \
@@ -51,9 +53,9 @@ class RoundTripTask(object):
         self.output_file.close()
         self.stderr_file.close()
 
-        with open(self.output_file.name, 'r') as stdout_in:
+        with open(self.output_file.name, 'rb') as stdout_in:
             self.stdout = stdout_in.read()
-        with open(self.stderr_file.name, 'r') as stderr_in:
+        with open(self.stderr_file.name, 'rb') as stderr_in:
             self.stderr = stderr_in.read()
 
         os.remove(self.output_file.name)
@@ -75,7 +77,7 @@ class RoundTripTask(object):
                 raise RuntimeError()
 
         contents = ''.join(map(lambda l: l.decode('utf-8', errors='replace'),
-                               open(self.input_filename).readlines()))
+                               open(self.input_filename, 'rb').readlines()))
         stdout_contents = self.stdout.decode('utf-8', errors='replace')
 
         if contents == stdout_contents:
@@ -92,7 +94,7 @@ def swift_files_in_dir(d):
     swift_files = []
     for root, dirs, files in os.walk(d):
         for basename in files:
-            if not basename.decode('utf-8').endswith('.swift'):
+            if not basename.endswith('.swift'):
                 continue
             abs_file = os.path.abspath(os.path.join(root, basename))
             swift_files.append(abs_file)
@@ -149,7 +151,8 @@ This driver invokes swift-syntax-test using -round-trip-lex and
     all_input_files = [filename for dir_listing in dir_listings
                        for filename in dir_listing]
     all_input_files += args.individual_input_files
-    all_input_files = [f.decode('utf-8') for f in all_input_files]
+    if sys.version_info[0] < 3:
+        all_input_files = [f.decode('utf-8') for f in all_input_files]
 
     if len(all_input_files) == 0:
         logging.error('No input files!')

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -2,5 +2,5 @@
 
 var d = [String:String]()
 _ = "\(d.map{ [$0 : $0] })"
-// expected-error@-1 {{type 'Dictionary<String, String>.Element' (aka '(key: String, value: String)') cannot conform to 'Hashable'; only struct/enum/class types can conform to protocols}}
+// expected-error@-1 {{type 'Dictionary<String, String>.Element' (aka '(key: String, value: String)') cannot conform to 'Hashable'; only concrete types such as structs, enums and classes can conform to protocols}}
 // expected-note@-2 {{required by generic struct 'Dictionary' where 'Key' = 'Dictionary<String, String>.Element' (aka '(key: String, value: String)')}}

--- a/validation-test/compiler_crashers_2_fixed/0196-rdar48937223.swift
+++ b/validation-test/compiler_crashers_2_fixed/0196-rdar48937223.swift
@@ -6,7 +6,7 @@ func fn<T, U: P>(_ arg1: T, arg2: (T) -> U) {}
 // expected-note@-1 {{required by global function 'fn(_:arg2:)' where 'U' = '()'}}
 
 func test(str: String) {
-  fn(str) { arg in // expected-error {{type '()' cannot conform to 'P'; only struct/enum/class types can conform to protocols}}
+  fn(str) { arg in // expected-error {{type '()' cannot conform to 'P'; only concrete types such as structs, enums and classes can conform to protocols}}
     <#FOO#> // expected-error {{editor placeholder in source file}}
   }
 }

--- a/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
@@ -20,4 +20,4 @@ extension Bool : BooleanProtocol {
 func f<T : BooleanProtocol>(_ b: T) {}
 // expected-note@-1 {{required by global function 'f' where 'T' = 'BooleanProtocol'}}
 
-f(true as BooleanProtocol) // expected-error {{value of protocol type 'BooleanProtocol' cannot conform to 'BooleanProtocol'; only struct/enum/class types can conform to protocols}}
+f(true as BooleanProtocol) // expected-error {{protocol 'BooleanProtocol' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}


### PR DESCRIPTION
- https://github.com/swiftwasm/swift/commit/d365616a58bea7bdb7d856f43e0e80c9607cf495 : Add WASI OS condition for stdlib/public/Differentiation/TgmathDerivatives.swift.gyb

- https://github.com/swiftwasm/swift/pull/1370/commits/b4457808fd5a0e1e0ecccd3c46fcfd13d721ac03 : https://github.com/apple/swift/commit/bc27356d73a5b6ee6233f1604e0225c89e0d9563 revealed that `_swift_setImmutableCOWBuffer` and `_swift_isImmutableCOWBuffer` are defined as C calling convention but called as swiftcc. So added swiftcc annotation to them. This change is related to https://github.com/apple/swift/pull/30938