### PR TITLE
Attempt to bootstrap SwiftPM on macOS

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2510,6 +2510,8 @@ extra-cmake-options=
 [preset: webassembly-macos]
 
 mixin-preset=webassembly
+swiftpm
+install-swiftpm
 extra-cmake-options=
     -DWASI_ICU_URL:STRING="https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
     -DWASI_ICU_MD5:STRING="25943864ebbfff15cf5aee8d9d5cc4d7"

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -64,8 +64,11 @@ cp -r $WASI_SDK_PATH/lib/clang usr/lib
 cp -a $WASI_SDK_PATH/bin/{*ld,llvm-ar} usr/bin
 cp -r $WASI_SDK_PATH/share/wasi-sysroot usr/share
 
-# Build SwiftPM and install it into toolchain
-$UTILS_PATH/build-swiftpm.sh $TMP_DIR/$TOOLCHAIN_NAME
+if [[ "$(uname)" == "Linux" ]]; then
+  # Build SwiftPM and install it into toolchain.
+  # On macOS it's built as a part of the preset.
+  $UTILS_PATH/build-swiftpm.sh $TMP_DIR/$TOOLCHAIN_NAME
+else
 
 # Replace absolute sysroot path with relative path
 sed -i -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" $TMP_DIR/$TOOLCHAIN_NAME/usr/lib/swift/wasi/wasm32/glibc.modulemap


### PR DESCRIPTION
This is an attempt to resolve #1365. The current theory is that SwiftPM and `libPackageDescription.dylib` are built with the host nightly toolchain built by the upstream Jenkins CI, but then `Package.swift` manifests are built with `swiftc` from the toolchain built by our SwiftWasm CI and then linked with that `libPackageDescription.dylib` from the upstream nightly snapshot, and these two are incompatible for some reason. I haven't fully verified this theory though, just setting this up to get a proper CI build for verification.