### PR TITLE
Print free space on CI after build is complete

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,14 @@ jobs:
           path: ../build-cache
           key: ${{ runner.os }}-sccache-v7
       - name: Build Linux installable archive
+        shell: bash
         run: |
+          set -ex
+
           ./utils/webassembly/ci.sh
           echo "Cleanup build directory to free disk space"
           rm -rf ../build
+          df -h
       - name: Upload Linux installable archive
         uses: actions/upload-artifact@v1
         with:
@@ -63,9 +67,13 @@ jobs:
           path: ../build-cache
           key: ${{ runner.os }}-sccache-v7
       - name: Build macOS installable archive
+        shell: bash
         run: |
+          set -ex
+
           sudo xcode-select --switch /Applications/Xcode_12_beta.app/Contents/Developer/
           ./utils/webassembly/ci.sh
+          df -h
       - name: Upload macOS installable archive
         uses: actions/upload-artifact@v1
         with:

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -16,7 +16,7 @@ SOURCE_PATH="$( cd "$(dirname $0)/../../../.." && pwd )"
 SWIFT_PATH=$SOURCE_PATH/swift
 cd $SWIFT_PATH
 
-./utils/update-checkout --clone --scheme wasm --skip-repository swift
+./utils/update-checkout --clone --scheme wasm --skip-history --skip-repository swift
 
 # Install wasmer
 

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -9,7 +9,7 @@ SOURCE_PATH="$( cd "$(dirname $0)/../../../../" && pwd  )"
 SWIFT_PATH=$SOURCE_PATH/swift
 cd $SWIFT_PATH
 
-./utils/update-checkout --clone --scheme wasm --skip-repository swift
+./utils/update-checkout --clone --scheme wasm --skip-history --skip-repository swift
 
 cd $SOURCE_PATH
 


### PR DESCRIPTION
I'm thinking of passing `--skip-history` to the `update-checkout` script on CI, but need to compare how much space that would actually free up.