### PR TITLE
Update WASI SDK to fix C++ setjmp/signal headers

### DIFF
--- a/utils/webassembly/install-wasi-sdk.sh
+++ b/utils/webassembly/install-wasi-sdk.sh
@@ -6,7 +6,7 @@ SOURCE_PATH="$( cd "$(dirname $0)/../../../" && pwd  )"
 
 cd $SOURCE_PATH
 
-WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.1-swiftwasm/dist-$2-latest.zip"
+WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.2-swiftwasm/dist-$2.zip"
 
 [ ! -e dist-wasi-sdk.zip ] && \
   wget -O dist-wasi-sdk.zip $WASI_SDK_URL

--- a/utils/webassembly/install-wasi-sdk.sh
+++ b/utils/webassembly/install-wasi-sdk.sh
@@ -6,11 +6,11 @@ SOURCE_PATH="$( cd "$(dirname $0)/../../../" && pwd  )"
 
 cd $SOURCE_PATH
 
-WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-$2-latest.tgz.zip"
+WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.1-swiftwasm/dist-$2-latest.zip"
 
-[ ! -e dist-wasi-sdk.tgz.zip ] && \
-  wget -O dist-wasi-sdk.tgz.zip $WASI_SDK_URL
-unzip -u dist-wasi-sdk.tgz.zip -d .
+[ ! -e dist-wasi-sdk.zip ] && \
+  wget -O dist-wasi-sdk.zip $WASI_SDK_URL
+unzip -u dist-wasi-sdk.zip -d .
 WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
 WASI_SDK_FULL_NAME=$(basename $WASI_SDK_TAR_PATH -$1.tar.gz)
 tar xfz $WASI_SDK_TAR_PATH

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -36,7 +36,7 @@ fi
 
 cmake --version
 
-$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh linux ubuntu
+$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh linux ubuntu-18.04
 
 # Link wasm32-wasi-unknown to wasm32-wasi because clang finds crt1.o from sysroot
 # with os and environment name `getMultiarchTriple`.

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -13,7 +13,7 @@ cd $SWIFT_PATH
 
 cd $SOURCE_PATH
 
-$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh macos macos
+$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh macos macos-10.15
 
 # Link sysroot/usr/include to sysroot/include because Darwin sysroot doesn't 
 # find header files in sysroot/include but sysroot/usr/include


### PR DESCRIPTION
Fixes the issue https://github.com/swiftwasm/swift/issues/595 with C++ packages for the development snapshots made from the `swiftwasm` branch. Previously C++ dependencies couldn't be built as default Clang headers weren't tailored to support WASI, https://github.com/WebAssembly/wasi-sdk/issues/93 being one of the examples.

@carson-katri this should unblock https://github.com/swiftwasm/Tokamak/pull/170, sorry for the delay. I had to to verify this locally and also then compile [a new release of our forked WASI SDK](https://github.com/swiftwasm/wasi-sdk), where CI iteration time is also close to 2 hours as it compiles LLVM from scratch, separately from our main SwiftWasm toolchain.