### PR TITLE
Add IndexStore to the host toolchain in 5.3 branch

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2428,7 +2428,7 @@ skip-build-benchmarks
 llvm-targets-to-build=X86;WebAssembly
 install-destdir=%(INSTALL_DESTDIR)s
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;testsuite-tools;toolchain-tools;license;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers;clang-resource-dir-symlink
-llvm-install-components=clang
+llvm-install-components=IndexStore;clang
 install-swift
 install-prefix=/%(TOOLCHAIN_NAME)s/usr
 
@@ -2440,9 +2440,12 @@ extra-cmake-options=
     -DSWIFT_ENABLE_SOURCEKIT_TESTS=FALSE
     -DSWIFT_BUILD_SYNTAXPARSERLIB=FALSE
 
+libcxx
 llbuild
 swiftpm
+indexstore-db
 
+install-libcxx
 install-llvm
 install-swift
 install-llbuild


### PR DESCRIPTION
Attempt to resolve the https://github.com/swiftwasm/swift/issues/1495 `--enable-test-discovery` issue in the 5.3 release branch.