### PR TITLE
Fix run filtering in nightly distribution script

### DIFF
--- a/utils/webassembly/distribute-latest-toolchain.sh
+++ b/utils/webassembly/distribute-latest-toolchain.sh
@@ -11,10 +11,10 @@ github() {
   curl --header "authorization: Bearer $GITHUB_TOKEN" "$@"
 }
 
-latest_run=$(github "${gh_api}/repos/${repository}/actions/workflows/${workflow_name}/runs?branch=${branch}&status=completed" | jq '.workflow_runs | sort_by(.run_number) | last')
+latest_run=$(github "${gh_api}/repos/${repository}/actions/workflows/${workflow_name}/runs?head_branch=${branch}&status=completed&conclusion=success" \
+  | jq ".workflow_runs | map(select(.head_branch == \"$branch\")) | sort_by(.run_number) | last")
 artifacts_url=$(echo $latest_run | jq .artifacts_url --raw-output)
 head_sha=$(echo $latest_run | jq .head_sha --raw-output)
-
 
 get_artifact_url() {
   local name=$1


### PR DESCRIPTION
Currently the script filters out completed runs, but failed runs are completed too and end up as candidates for nightly distribution. This is fixed by passing the additional `conclusion=success` argument to the API request. Additionally the `branch` API request argument does substring filtering, which means that `swiftwasm-release/5.3` runs end up as candidates for `swiftwasm` snapshots, since the former is a substring of the latter. I've added exact string filtering to the `jq` pipeline to fix this.