### PR TITLE
Fix local test runs by passing real test dir path

### DIFF
--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -125,3 +125,4 @@ merge_toolchains
 
 cd "$DIST_TOOLCHAIN_DESTDIR"
 tar cfz "$PACKAGE_ARTIFACT" "$TOOLCHAIN_NAME"
+echo "Toolchain archive created successfully!"

--- a/utils/webassembly/ci.sh
+++ b/utils/webassembly/ci.sh
@@ -37,14 +37,18 @@ $BUILD_SCRIPT
 if [[ "$(uname)" == "Darwin" ]]; then
   # workaround: host target test directory is necessary to use run-test
   mkdir -p $TARGET_BUILD_DIR/swift-macosx-x86_64/test-macosx-x86_64
+  HOST_PLATFORM=macosx
+else
+  HOST_PLATFORM=linux
 fi
 
 if [[ "$(uname)" == "Linux" ]]; then
-  $RUN_TEST_BIN --build-dir $TARGET_BUILD_DIR --target wasi-wasm32 test/stdlib/
+  $RUN_TEST_BIN --build-dir $TARGET_BUILD_DIR --target wasi-wasm32 \
+    $TARGET_BUILD_DIR/swift-${HOST_PLATFORM}-x86_64/test-wasi-wasm32/stdlib
   echo "Skip running test suites for Linux"
 else
-
-  $RUN_TEST_BIN --build-dir $TARGET_BUILD_DIR --target wasi-wasm32 test/stdlib/
+  $RUN_TEST_BIN --build-dir $TARGET_BUILD_DIR --target wasi-wasm32 \
+ 	$TARGET_BUILD_DIR/swift-${HOST_PLATFORM}-x86_64/test-wasi-wasm32/stdlib
 
   # Run test but ignore failure temporarily
   ninja check-swift-wasi-wasm32 -C $TARGET_BUILD_DIR/swift-$HOST_SUFFIX || true

--- a/utils/webassembly/ci.sh
+++ b/utils/webassembly/ci.sh
@@ -34,6 +34,8 @@ export SCCACHE_DIR="$SOURCE_PATH/build-cache"
 
 $BUILD_SCRIPT
 
+echo "Build script completed, will attempt to run test suites..."
+
 if [[ "$(uname)" == "Darwin" ]]; then
   # workaround: host target test directory is necessary to use run-test
   mkdir -p $TARGET_BUILD_DIR/swift-macosx-x86_64/test-macosx-x86_64
@@ -53,3 +55,5 @@ else
   # Run test but ignore failure temporarily
   ninja check-swift-wasi-wasm32 -C $TARGET_BUILD_DIR/swift-$HOST_SUFFIX || true
 fi
+
+echo "The test suite has finished"


### PR DESCRIPTION
For some reason when running `ci.sh` locally the test path is inferred incorrectly. Here I'm changing the script to pass the test path directly without relying on the broken inference logic.

Same as #1684, but cherry-picked for `swiftwasm`.