### PR TITLE
[WASM] Update assertion condition for keypath projector

### DIFF
--- a/lib/SILOptimizer/Utils/KeyPathProjector.cpp
+++ b/lib/SILOptimizer/Utils/KeyPathProjector.cpp
@@ -230,7 +230,11 @@ public:
       auto addr = builder.createAllocStack(loc, type);
       
       assertHasNoContext();
-      assert(getter->getArguments().size() == 2);
+      // For wasm, SILGen emit keypath projecter with extra generic param
+      // argument to match callee and caller signature even if it doesn't
+      // have generic param.
+      auto target = builder.getASTContext().LangOpts.Target;
+      assert(getter->getArguments().size() == 2 + target.isOSBinFormatWasm());
       
       auto ref = builder.createFunctionRef(loc, getter);
       builder.createApply(loc, ref, subs, {addr, parentValue});


### PR DESCRIPTION
This assertion failed when building Tokamak in release mode (version 0.3.0)

Please cherry-pick me into 5.3 branch also.