### PR TITLE
Fix latest run check in toolchain upload script

### DIFF
--- a/utils/webassembly/distribute-latest-toolchain.sh
+++ b/utils/webassembly/distribute-latest-toolchain.sh
@@ -13,6 +13,12 @@ github() {
 
 latest_run=$(github "${gh_api}/repos/${repository}/actions/workflows/${workflow_name}/runs?head_branch=${branch}&status=completed&conclusion=success" \
   | jq ".workflow_runs | map(select(.head_branch == \"$branch\")) | sort_by(.run_number) | last")
+
+if [ -z "$latest_run" ] || [ "$latest_run" == "null" ]; then
+  echo "No successful runs available"
+  exit 0
+fi
+
 artifacts_url=$(echo $latest_run | jq .artifacts_url --raw-output)
 head_sha=$(echo $latest_run | jq .head_sha --raw-output)
 


### PR DESCRIPTION
Currently, if there are no recent successful runs on GitHub Actions, the toolchain distribution script fails. Because of this the 5.3 toolchains are not uploaded even if there are successful runs for those. We should check for this scenario and just stop the script with `0` exit code to allow the 5.3 upload to proceed.