### PR TITLE
Prioritize SDK paths in CMake find_ functions in 5.3 branch

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -658,6 +658,12 @@ function set_build_options_for_host() {
 
             cmake_os_sysroot="$(xcrun --sdk ${platform} --show-sdk-path)"
 
+            # Give the SDK sysroot higher priority in calls to CMake `find_*`
+            # functions, over paths that may come from `pkg-config`. This fixes
+            # compile failures caused when `pkg-config` returns CommandLineTools
+            # paths instead of Xcode paths.
+            export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${cmake_os_sysroot}/usr"
+
             cmark_cmake_options=(
                 -DCMAKE_C_FLAGS="$(cmark_c_flags ${host})"
                 -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"


### PR DESCRIPTION
It looks like after https://github.com/actions/virtual-environments/commit/ff1423cd6f345ef56adcf8e3e8585908f742f740 was deployed, the [SR-12726](https://bugs.swift.org/browse/SR-12726) bug is now reproducible on GitHub Actions. It was fixed in upstream `master`, but wasn't applied to upstream `release/5.3`, I'm re-applying it to the release branch here.