### PR TITLE
[WASM] Fix KeyPath optimization bug around signature match

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -250,6 +250,10 @@ getAccessorForComputedComponent(IRGenModule &IGM,
                                forwardingSubs,
                                &ignoreWitnessMetadata,
                                forwardedArgs);
+    } else if (IGM.Triple.isOSBinFormatWasm()) {
+      // wasm: Add null swift.type pointer to match signature even when there is
+      // no generic environment.
+      forwardedArgs.add(llvm::ConstantPointerNull::get(IGM.TypeMetadataPtrTy));
     }
     auto fnPtr = FunctionPointer::forDirect(IGM, accessorFn,
                                           accessor->getLoweredFunctionType());

--- a/lib/SILOptimizer/Utils/KeyPathProjector.cpp
+++ b/lib/SILOptimizer/Utils/KeyPathProjector.cpp
@@ -237,7 +237,22 @@ public:
       assert(getter->getArguments().size() == 2 + target.isOSBinFormatWasm());
       
       auto ref = builder.createFunctionRef(loc, getter);
-      builder.createApply(loc, ref, subs, {addr, parentValue});
+
+      std::vector<SILValue> args{addr, parentValue};
+      // FIXME(wasm): For wasm, KeyPath getter always take indices parameter
+      // to match callee and caller signature. So need to pass stub pointer.
+      // See also: getOrCreateKeyPathSetter and getOrCreateKeyPathGetter
+      if (builder.getASTContext().LangOpts.Target.isOSBinFormatWasm()) {
+        auto IntTy = SILType::getBuiltinIntegerType(32, builder.getASTContext());
+        auto UnsafeRawPointerTy = SILType::getRawPointerType(builder.getASTContext());
+        auto zeroVal = SILValue(builder.createIntegerLiteral(loc, IntTy, 0));
+        auto stackBuffer = SILValue(builder.createAllocStack(loc, IntTy));
+        builder.createStore(loc, zeroVal, stackBuffer, StoreOwnershipQualifier::Unqualified);
+        auto nonePointer = builder.createUncheckedAddrCast(loc, stackBuffer, UnsafeRawPointerTy);
+        args.push_back(SILValue(nonePointer));
+      }
+
+      builder.createApply(loc, ref, subs, args);
       
       // If we were previously accessing a class member, we're done now.
       insertEndAccess(beginAccess, builder);


### PR DESCRIPTION
For wasm, KeyPath getter always take indices parameter to match callee and caller signature. So need to pass stub pointer.

Ideally, we should mark these optional arguments with special attribute and lower them correctly.

Resolve https://github.com/swiftwasm/swift/issues/1679