### PR TITLE
Remove Glibc references from wasi.modulemap.gyb

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -57,8 +57,8 @@ if(WASI IN_LIST SWIFT_SDKS)
   handle_gyb_source_single(wasi_libc_modulemap_target
     SOURCE "wasi.modulemap.gyb"
     OUTPUT "${wasi_libc_modulemap_out}"
-    FLAGS "-DGLIBC_INCLUDE_PATH=${SWIFT_SDK_WASI_ARCH_wasm32_LIBC_INCLUDE_DIRECTORY}"
-          "-DGLIBC_ARCH_INCLUDE_PATH=${SWIFT_SDK_WASI_ARCH_wasm32_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY}")
+    FLAGS "-DLIBC_INCLUDE_PATH=${SWIFT_SDK_WASI_ARCH_wasm32_LIBC_INCLUDE_DIRECTORY}"
+          "-DLIBC_ARCH_INCLUDE_PATH=${SWIFT_SDK_WASI_ARCH_wasm32_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY}")
   add_custom_command_target(
     copy_wasi_libc_modulemap_static
     COMMAND

--- a/stdlib/public/Platform/wasi.modulemap.gyb
+++ b/stdlib/public/Platform/wasi.modulemap.gyb
@@ -22,93 +22,93 @@ module SwiftWASILibc [system] {
   // C standard library
   module C {
     module ctype {
-      header "${GLIBC_INCLUDE_PATH}/ctype.h"
+      header "${LIBC_INCLUDE_PATH}/ctype.h"
       export *
     }
     module errno {
-      header "${GLIBC_INCLUDE_PATH}/errno.h"
+      header "${LIBC_INCLUDE_PATH}/errno.h"
       export *
     }
 
     module fenv {
-      header "${GLIBC_INCLUDE_PATH}/fenv.h"
+      header "${LIBC_INCLUDE_PATH}/fenv.h"
       export *
     }
 
     // note: supplied by compiler
     // module float {
-    //   header "${GLIBC_INCLUDE_PATH}/float.h"
+    //   header "${LIBC_INCLUDE_PATH}/float.h"
     //   export *
     // }
 
     module inttypes {
-      header "${GLIBC_INCLUDE_PATH}/inttypes.h"
+      header "${LIBC_INCLUDE_PATH}/inttypes.h"
       export *
     }
 
     // note: potentially supplied by compiler
     // module iso646 {
-    //   header "${GLIBC_INCLUDE_PATH}/iso646.h"
+    //   header "${LIBC_INCLUDE_PATH}/iso646.h"
     //   export *
     // }
     // module limits {
-    //   header "${GLIBC_INCLUDE_PATH}/limits.h"
+    //   header "${LIBC_INCLUDE_PATH}/limits.h"
     //   export *
     // }
 
     module locale {
-      header "${GLIBC_INCLUDE_PATH}/locale.h"
+      header "${LIBC_INCLUDE_PATH}/locale.h"
       export *
     }
     module math {
-      header "${GLIBC_INCLUDE_PATH}/math.h"
+      header "${LIBC_INCLUDE_PATH}/math.h"
       export *
     }
     module signal {
-      header "${GLIBC_INCLUDE_PATH}/signal.h"
+      header "${LIBC_INCLUDE_PATH}/signal.h"
       export *
     }
 
     // note: supplied by the compiler
     // module stdarg {
-    //   header "${GLIBC_INCLUDE_PATH}/stdarg.h"
+    //   header "${LIBC_INCLUDE_PATH}/stdarg.h"
     //   export *
     // }
     // module stdbool {
-    //   header "${GLIBC_INCLUDE_PATH}/stdbool.h"
+    //   header "${LIBC_INCLUDE_PATH}/stdbool.h"
     //   export *
     // }
     // module stddef {
-    //   header "${GLIBC_INCLUDE_PATH}/stddef.h"
+    //   header "${LIBC_INCLUDE_PATH}/stddef.h"
     //   export *
     // }
     // module stdint {
-    //   header "${GLIBC_INCLUDE_PATH}/stdint.h"
+    //   header "${LIBC_INCLUDE_PATH}/stdint.h"
     //   export *
     // }
 
     module stdio {
-      header "${GLIBC_INCLUDE_PATH}/stdio.h"
+      header "${LIBC_INCLUDE_PATH}/stdio.h"
       export *
     }
     module stdlib {
-      header "${GLIBC_INCLUDE_PATH}/stdlib.h"
+      header "${LIBC_INCLUDE_PATH}/stdlib.h"
       export *
       export stddef
     }
     module string {
-      header "${GLIBC_INCLUDE_PATH}/string.h"
+      header "${LIBC_INCLUDE_PATH}/string.h"
       export *
     }
 
     // note: supplied by the compiler
     // explicit module tgmath {
-    //   header "${GLIBC_INCLUDE_PATH}/tgmath.h"
+    //   header "${LIBC_INCLUDE_PATH}/tgmath.h"
     //   export *
     // }
 
     module time {
-      header "${GLIBC_INCLUDE_PATH}/time.h"
+      header "${LIBC_INCLUDE_PATH}/time.h"
       export *
     }
   }
@@ -117,61 +117,61 @@ module SwiftWASILibc [system] {
   module POSIX {
     module arpa {
       module inet {
-        header "${GLIBC_INCLUDE_PATH}/arpa/inet.h"
+        header "${LIBC_INCLUDE_PATH}/arpa/inet.h"
         export *
       }
       export *
     }
     module dirent {
-      header "${GLIBC_INCLUDE_PATH}/dirent.h"
+      header "${LIBC_INCLUDE_PATH}/dirent.h"
       export *
     }
     module fcntl {
-      header "${GLIBC_INCLUDE_PATH}/fcntl.h"
+      header "${LIBC_INCLUDE_PATH}/fcntl.h"
       export *
     }
     module fnmatch {
-      header "${GLIBC_INCLUDE_PATH}/fnmatch.h"
+      header "${LIBC_INCLUDE_PATH}/fnmatch.h"
       export *
     }
     module ioctl {
-      header "${GLIBC_ARCH_INCLUDE_PATH}/sys/ioctl.h"
+      header "${LIBC_ARCH_INCLUDE_PATH}/sys/ioctl.h"
       export *
     }
     module libgen {
-      header "${GLIBC_INCLUDE_PATH}/libgen.h"
+      header "${LIBC_INCLUDE_PATH}/libgen.h"
       export *
     }
     module netinet {
       module in {
-        header "${GLIBC_INCLUDE_PATH}/netinet/in.h"
+        header "${LIBC_INCLUDE_PATH}/netinet/in.h"
         export *
 
-        exclude header "${GLIBC_INCLUDE_PATH}/netinet6/in6.h"
+        exclude header "${LIBC_INCLUDE_PATH}/netinet6/in6.h"
       }
       module tcp {
-        header "${GLIBC_INCLUDE_PATH}/netinet/tcp.h"
+        header "${LIBC_INCLUDE_PATH}/netinet/tcp.h"
         export *
       }
     }
     module poll {
-      header "${GLIBC_INCLUDE_PATH}/poll.h"
+      header "${LIBC_INCLUDE_PATH}/poll.h"
       export *
     }
     module regex {
-      header "${GLIBC_INCLUDE_PATH}/regex.h"
+      header "${LIBC_INCLUDE_PATH}/regex.h"
       export *
     }
     module sched {
-      header "${GLIBC_INCLUDE_PATH}/sched.h"
+      header "${LIBC_INCLUDE_PATH}/sched.h"
       export *
     }
     module semaphore {
-      header "${GLIBC_INCLUDE_PATH}/semaphore.h"
+      header "${LIBC_INCLUDE_PATH}/semaphore.h"
       export *
     }
     module strings {
-      header "${GLIBC_INCLUDE_PATH}/strings.h"
+      header "${LIBC_INCLUDE_PATH}/strings.h"
       export *
     }
 
@@ -179,52 +179,52 @@ module SwiftWASILibc [system] {
       export *
 
       module mman {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/mman.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/mman.h"
         export *
       }
       module resource {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/resource.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/resource.h"
         export *
       }
       module select {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/select.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/select.h"
         export *
       }
       module socket {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/socket.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/socket.h"
         export *
       }
       module stat {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/stat.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/stat.h"
         export *
       }
       module time {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/time.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/time.h"
         export *
       }
       module times {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/times.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/times.h"
         export *
       }
       module types {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/types.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/types.h"
         export *
       }
       module uio {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/uio.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/uio.h"
         export *
       }
       module un {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/un.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/un.h"
         export *
       }
       module utsname {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/utsname.h"
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/utsname.h"
         export *
       }
     }
     module unistd {
-      header "${GLIBC_INCLUDE_PATH}/unistd.h"
+      header "${LIBC_INCLUDE_PATH}/unistd.h"
       export *
     }
   }


### PR DESCRIPTION
I'll submit the new modulemap upstream later, and this PR is a clean up in preparation for that.