### PR TITLE
Suppress lld assertion warnings temporarily

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2594,6 +2594,7 @@ extra-cmake-options=
     -DSWIFT_ENABLE_SOURCEKIT_TESTS=FALSE
     -DSWIFT_BUILD_SYNTAXPARSERLIB=FALSE
 
+swift-enable-assertions=false
 llbuild
 swiftpm
 indexstore-db


### PR DESCRIPTION
I couldn't find the root reason why wasm-ld warns reloc validation, but I found why the warnings were suddenly appeared.

After https://github.com/swiftwasm/swift/pull/1582 merged, our toolchain started to use self-built wasm-ld instead of wasi-sdk's version to sync LLVM version between compiler and linker. But the wasm-ld is built with `LLVM_ENABLE_ASSERTIONS=true`, so it verifies reloc records while linking.

I disabled runtime assertions temporarily. I suspect that LLVM backend put invalid offset on relocation point.

Resolve https://github.com/swiftwasm/swift/issues/1823