### PR TITLE
[WASM] Re-enable all stdlib tests on Linux

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1437,7 +1437,7 @@ elif run_os == 'wasi':
         config.swift_test_options, config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = '%s run --backend cranelift --' % config.wasmer
+    config.target_run = '%s run --singlepass --' % config.wasmer
     if 'interpret' in lit_config.params:
         use_interpreter_for_simple_runs()
     config.target_sil_opt = (

--- a/utils/webassembly/ci.sh
+++ b/utils/webassembly/ci.sh
@@ -40,7 +40,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 if [[ "$(uname)" == "Linux" ]]; then
-  $RUN_TEST_BIN --build-dir $TARGET_BUILD_DIR --target wasi-wasm32 test/stdlib/ || true
+  $RUN_TEST_BIN --build-dir $TARGET_BUILD_DIR --target wasi-wasm32 test/stdlib/
   echo "Skip running test suites for Linux"
 else
 

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -3,7 +3,13 @@
 set -ex
 
 brew uninstall $(brew list | grep python@2)
-brew install cmake ninja llvm sccache wasmer
+brew install cmake ninja llvm sccache
+
+# Install latest wasmer
+
+if [ ! -e ~/.wasmer/bin/wasmer ]; then
+  curl https://get.wasmer.io -sSfL | sh
+fi
 
 SOURCE_PATH="$( cd "$(dirname $0)/../../../../" && pwd  )"
 SWIFT_PATH=$SOURCE_PATH/swift


### PR DESCRIPTION
The wasmer cranelift backend is broken since 1.0.0-alpha3, so we use
singlepass backend instead until the bug will be resolved.

https://github.com/wasmerio/wasmer/issues/1674