### PR TITLE
State CPU arch in names of distribution tarballs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ubuntu18.04-installable
-          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu18.04.tar.gz
+          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu18.04-x86_64.tar.gz
 #      - name: Pack test results
 #        run: tar cJf swift-test-results.tar.gz ../build/*/swift-linux-x86_64/swift-test-results
 #      - name: Upload test results
@@ -95,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ubuntu20.04-installable
-          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu20.04.tar.gz
+          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu20.04-x86_64.tar.gz
 #      - name: Pack test results
 #        run: tar cJf swift-test-results.tar.gz ../build/*/swift-linux-x86_64/swift-test-results
 #      - name: Upload test results
@@ -132,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: macos-installable
-          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-osx.tar.gz
+          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-macos-x86_64.tar.gz
       - name: Pack test results
         working-directory: ${{ github.workspace }}/../
         run: |

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -8,16 +8,16 @@ WASI_SDK_PATH=$SOURCE_PATH/wasi-sdk
 
 case $(uname -s) in
   Darwin)
-    OS_SUFFIX=osx
+    OS_SUFFIX=macos-x86_64
     HOST_PRESET=webassembly-host-install
     TARGET_PRESET=webassembly-macos-target-install
     HOST_SUFFIX=macosx-x86_64
   ;;
   Linux)
     if [ "$(grep RELEASE /etc/lsb-release)" == "DISTRIB_RELEASE=18.04" ]; then
-      OS_SUFFIX=ubuntu18.04
+      OS_SUFFIX=ubuntu18.04-x86_64
     elif [ "$(grep RELEASE /etc/lsb-release)" == "DISTRIB_RELEASE=20.04" ]; then
-      OS_SUFFIX=ubuntu20.04
+      OS_SUFFIX=ubuntu20.04-x86_64
     else
       echo "Unknown Ubuntu version"
       exit 1

--- a/utils/webassembly/distribute-latest-toolchain.sh
+++ b/utils/webassembly/distribute-latest-toolchain.sh
@@ -103,22 +103,22 @@ unzip ubuntu18.04-installable.zip
 unzip ubuntu20.04-installable.zip
 unzip macos-installable.zip
 
-toolchain_name=$(basename $(tar tfz swift-wasm-$2-SNAPSHOT-ubuntu18.04.tar.gz | head -n1))
+toolchain_name=$(basename $(tar tfz swift-wasm-$2-SNAPSHOT-ubuntu18.04-x86_64.tar.gz | head -n1))
 
 if is_released $toolchain_name; then
   echo "Latest toolchain $toolchain_name has been already released"
   exit 0
 fi
 
-mv swift-wasm-$2-SNAPSHOT-ubuntu18.04.tar.gz "$toolchain_name-ubuntu18.04-x86_64.tar.gz"
-mv swift-wasm-$2-SNAPSHOT-ubuntu20.04.tar.gz "$toolchain_name-ubuntu20.04-x86_64.tar.gz"
-mv swift-wasm-$2-SNAPSHOT-osx.tar.gz "$toolchain_name-macos-x86_64.tar.gz"
+mv swift-wasm-$2-SNAPSHOT-ubuntu18.04-x86_64.tar.gz "$toolchain_name-ubuntu18.04-x86_64.tar.gz"
+mv swift-wasm-$2-SNAPSHOT-ubuntu20.04-x86_64.tar.gz "$toolchain_name-ubuntu20.04-x86_64.tar.gz"
+mv swift-wasm-$2-SNAPSHOT-macos-x86_64.tar.gz "$toolchain_name-macos-x86_64.tar.gz"
 
 create_tag $toolchain_name $head_sha
 release_id=$(create_release $toolchain_name $toolchain_name $head_sha)
 
-upload_tarball $release_id "$toolchain_name-ubuntu18.04.tar.gz"
-upload_tarball $release_id "$toolchain_name-ubuntu20.04.tar.gz"
-upload_tarball $release_id "$toolchain_name-macos-x86_64.tar.gz"
+upload_tarball $release_id "$toolchain_name-ubuntu18.04-x86_64.tar.gz"
+upload_tarball $release_id "$toolchain_name-ubuntu20.04-x86_64.tar.gz"
+upload_tarball $release_id "$toolchain_name-macos-x86_64-x86_64.tar.gz"
 
 popd

--- a/utils/webassembly/distribute-latest-toolchain.sh
+++ b/utils/webassembly/distribute-latest-toolchain.sh
@@ -110,15 +110,15 @@ if is_released $toolchain_name; then
   exit 0
 fi
 
-mv swift-wasm-$2-SNAPSHOT-ubuntu18.04.tar.gz "$toolchain_name-ubuntu18.04.tar.gz"
-mv swift-wasm-$2-SNAPSHOT-ubuntu20.04.tar.gz "$toolchain_name-ubuntu20.04.tar.gz"
-mv swift-wasm-$2-SNAPSHOT-osx.tar.gz "$toolchain_name-osx.tar.gz"
+mv swift-wasm-$2-SNAPSHOT-ubuntu18.04.tar.gz "$toolchain_name-ubuntu18.04-x86_64.tar.gz"
+mv swift-wasm-$2-SNAPSHOT-ubuntu20.04.tar.gz "$toolchain_name-ubuntu20.04-x86_64.tar.gz"
+mv swift-wasm-$2-SNAPSHOT-osx.tar.gz "$toolchain_name-macos-x86_64.tar.gz"
 
 create_tag $toolchain_name $head_sha
 release_id=$(create_release $toolchain_name $toolchain_name $head_sha)
 
 upload_tarball $release_id "$toolchain_name-ubuntu18.04.tar.gz"
 upload_tarball $release_id "$toolchain_name-ubuntu20.04.tar.gz"
-upload_tarball $release_id "$toolchain_name-osx.tar.gz"
+upload_tarball $release_id "$toolchain_name-macos-x86_64.tar.gz"
 
 popd


### PR DESCRIPTION
As we'd like to provide arm64 builds in the future, we have to make it clear which CPU architecture is supported in a given distribution tarball.