### PR TITLE
Check if Python 2 is installed before uninstalling

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -97,7 +97,7 @@
                 "cmake": "v3.16.5",               
                 "indexstore-db": "release/5.3",
                 "sourcekit-lsp": "release/5.3",
-                "swift-format": "master"
+                "swift-format": "main"
             }
         },
         "master": {

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -2,7 +2,10 @@
 
 set -ex
 
-brew uninstall $(brew list | grep python@2)
+if [ -n "$(brew list | grep python@2)" ]; then
+  brew uninstall $(brew list | grep python@2)
+fi
+
 brew install cmake ninja llvm sccache
 
 # Install latest wasmer


### PR DESCRIPTION
This simplifies local development, where Python 2 may not be installed.