### PR TITLE
Add missing packages to linux/install-dependencies.sh

### DIFF
--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -9,9 +9,9 @@ if [ $(grep RELEASE /etc/lsb-release) == "DISTRIB_RELEASE=18.04" ]; then
     git ninja-build clang-10 python python-six \
     uuid-dev libicu-dev icu-devtools libbsd-dev \
     libedit-dev libxml2-dev libsqlite3-dev swig \
-    libpython-dev libncurses5-dev pkg-config \
+    libpython-dev libncurses5 libncurses5-dev pkg-config \
     libblocksruntime-dev libcurl4-openssl-dev \
-    systemtap-sdt-dev tzdata rsync wget llvm-10 zip unzip
+    make systemtap-sdt-dev tzdata rsync wget llvm-10 zip unzip
   sudo ln -s -f /usr/bin/clang-10 /usr/bin/clang
   sudo ln -s -f /usr/bin/clang++-10 /usr/bin/clang++
 elif [ $(grep RELEASE /etc/lsb-release) == "DISTRIB_RELEASE=20.04" ]; then
@@ -19,9 +19,9 @@ elif [ $(grep RELEASE /etc/lsb-release) == "DISTRIB_RELEASE=20.04" ]; then
     git ninja-build clang python python-six \
     uuid-dev libicu-dev icu-devtools libbsd-dev \
     libedit-dev libxml2-dev libsqlite3-dev swig \
-    libpython2-dev libncurses5-dev pkg-config \
+    libpython2-dev libncurses5 libncurses5-dev pkg-config \
     libblocksruntime-dev libcurl4-openssl-dev \
-    systemtap-sdt-dev tzdata rsync wget llvm zip unzip
+    make systemtap-sdt-dev tzdata rsync wget llvm zip unzip
 else
   echo "Unknown Ubuntu version"
   exit 1


### PR DESCRIPTION
`libncurses5` and `make` are needed on Linux hosts other than GitHub Actions runners, e.g. VMs from cloud providers and Docker installations.