### PR TITLE
Set SWIFT_COMPILER_VERSION=5.3.0 in build presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2451,6 +2451,7 @@ install-prefix=/%(TOOLCHAIN_NAME)s/usr
 
 mixin-preset=webassembly
 extra-cmake-options=
+    -DSWIFT_COMPILER_VERSION="5.3.0"
     -DSWIFT_BUILD_SOURCEKIT=FALSE
     -DSWIFT_ENABLE_SOURCEKIT_TESTS=FALSE
     -DSWIFT_BUILD_SYNTAXPARSERLIB=FALSE
@@ -2504,6 +2505,7 @@ wasi-sdk=%(SOURCE_PATH)s/wasi-sdk
 
 mixin-preset=webassembly-target
 extra-cmake-options=
+    -DSWIFT_COMPILER_VERSION="5.3.0"
     -DWASI_ICU_URL:STRING="https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
     -DWASI_ICU_MD5:STRING="25943864ebbfff15cf5aee8d9d5cc4d7"
     -DSWIFT_PRIMARY_VARIANT_SDK:STRING=WASI
@@ -2519,6 +2521,7 @@ extra-cmake-options=
 
 mixin-preset=webassembly-target
 extra-cmake-options=
+    -DSWIFT_COMPILER_VERSION="5.3.0"
     -DWASI_ICU_URL:STRING="https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"
     -DWASI_ICU_MD5:STRING="25943864ebbfff15cf5aee8d9d5cc4d7"
     -DSWIFT_PRIMARY_VARIANT_SDK:STRING=WASI


### PR DESCRIPTION
I'm not sure there's anything else we can and want to include in this release. Let's bump the version and after this PR is merged use that snapshot for a bit as a release candidate. If all goes well, we'll tag it as a proper `wasm-5.3.0` release. 🙌