### PR TITLE
Use underscore for CPU arch in dist names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ubuntu18.04-installable
-          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu18.04-x86_64.tar.gz
+          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu18.04_x86_64.tar.gz
 #      - name: Pack test results
 #        run: tar cJf swift-test-results.tar.gz ../build/*/swift-linux-x86_64/swift-test-results
 #      - name: Upload test results
@@ -95,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ubuntu20.04-installable
-          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu20.04-x86_64.tar.gz
+          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-ubuntu20.04_x86_64.tar.gz
 #      - name: Pack test results
 #        run: tar cJf swift-test-results.tar.gz ../build/*/swift-linux-x86_64/swift-test-results
 #      - name: Upload test results
@@ -132,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: macos-installable
-          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-macos-x86_64.tar.gz
+          path: ../swift-wasm-DEVELOPMENT-SNAPSHOT-macos_x86_64.tar.gz
       - name: Pack test results
         working-directory: ${{ github.workspace }}/../
         run: |

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -8,16 +8,16 @@ WASI_SDK_PATH=$SOURCE_PATH/wasi-sdk
 
 case $(uname -s) in
   Darwin)
-    OS_SUFFIX=macos-x86_64
+    OS_SUFFIX=macos_x86_64
     HOST_PRESET=webassembly-host-install
     TARGET_PRESET=webassembly-macos-target-install
     HOST_SUFFIX=macosx-x86_64
   ;;
   Linux)
     if [ "$(grep RELEASE /etc/lsb-release)" == "DISTRIB_RELEASE=18.04" ]; then
-      OS_SUFFIX=ubuntu18.04-x86_64
+      OS_SUFFIX=ubuntu18.04_x86_64
     elif [ "$(grep RELEASE /etc/lsb-release)" == "DISTRIB_RELEASE=20.04" ]; then
-      OS_SUFFIX=ubuntu20.04-x86_64
+      OS_SUFFIX=ubuntu20.04_x86_64
     else
       echo "Unknown Ubuntu version"
       exit 1

--- a/utils/webassembly/distribute-latest-toolchain.sh
+++ b/utils/webassembly/distribute-latest-toolchain.sh
@@ -175,7 +175,7 @@ unzip ubuntu18.04-installable.zip
 unzip ubuntu20.04-installable.zip
 unzip macos-installable.zip
 
-toolchain_name=$(basename $(tar tfz swift-wasm-$channel-SNAPSHOT-ubuntu18.04-x86_64.tar.gz | head -n1))
+toolchain_name=$(basename $(tar tfz swift-wasm-$channel-SNAPSHOT-ubuntu18.04_x86_64.tar.gz | head -n1))
 
 if is_released $toolchain_name; then
   echo "Latest toolchain $toolchain_name has been already released"
@@ -183,15 +183,15 @@ if is_released $toolchain_name; then
 fi
 
 
-mv swift-wasm-$channel-SNAPSHOT-ubuntu18.04-x86_64.tar.gz "$toolchain_name-ubuntu18.04-x86_64.tar.gz"
-mv swift-wasm-$channel-SNAPSHOT-ubuntu20.04-x86_64.tar.gz "$toolchain_name-ubuntu20.04-x86_64.tar.gz"
-package_darwin_toolchain "swift-wasm-$channel-SNAPSHOT-macos-x86_64.tar.gz" "$toolchain_name-macos-x86_64.pkg"
+mv swift-wasm-$channel-SNAPSHOT-ubuntu18.04_x86_64.tar.gz "$toolchain_name-ubuntu18.04_x86_64.tar.gz"
+mv swift-wasm-$channel-SNAPSHOT-ubuntu20.04_x86_64.tar.gz "$toolchain_name-ubuntu20.04_x86_64.tar.gz"
+package_darwin_toolchain "swift-wasm-$channel-SNAPSHOT-macos_x86_64.tar.gz" "$toolchain_name-macos_x86_64.pkg"
 
 create_tag $toolchain_name $head_sha
 release_id=$(create_release $toolchain_name $toolchain_name $head_sha)
 
-upload_tarball $release_id "$toolchain_name-ubuntu18.04-x86_64.tar.gz"
-upload_tarball $release_id "$toolchain_name-ubuntu20.04-x86_64.tar.gz"
-upload_tarball $release_id "$toolchain_name-macos-x86_64.pkg"
+upload_tarball $release_id "$toolchain_name-ubuntu18.04_x86_64.tar.gz"
+upload_tarball $release_id "$toolchain_name-ubuntu20.04_x86_64.tar.gz"
+upload_tarball $release_id "$toolchain_name-macos_x86_64.pkg"
 
 popd


### PR DESCRIPTION
Currently `swiftenv` thinks that `-macos` and `-ubuntu18.04` are parts of the version bit, which forces us to hardcode it in `.swift-version` in projects that use this file. I hope that separating OS and CPU architecture in distribution names will fix this, and `swiftenv` will be able to parse the version from names properly again. 