### PR TITLE
Use macOS 10.15 on GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
 
   macos_build:
     timeout-minutes: 0
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
       - uses: actions/checkout@v1
@@ -145,7 +145,7 @@ jobs:
 
   macos_smoke_test:
     name: Run smoke tests on macOS
-    runs-on: macos-latest
+    runs-on: macos-10.15
     needs: macos_build
     steps:
       - name: Download installable macOS archive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
             ${{ runner.os }}-sccache-v10-
       - name: Build macOS installable archive
         run: |
-          sudo xcode-select --switch /Applications/Xcode_12.2.0.app/Contents/Developer/
+          sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer/
           ./utils/webassembly/ci.sh
       - name: Upload macOS installable archive
         uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Build macOS installable archive
         run: |
           sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer/
+          xcodebuild -version
           ./utils/webassembly/ci.sh
       - name: Upload macOS installable archive
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
This is in preparation for GitHub making macOS Big Sur the default at some point.