### PR TITLE
Remove sed backup file from toolchain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,9 @@ jobs:
           repository: swiftwasm/integration-tests
           path: integration-tests
       - name: Run integration tests
-        run: swift run # Use TOOLCHAIN env value
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer/
+          swift run # Use TOOLCHAIN env value
         working-directory: ${{ github.workspace }}/integration-tests
 
   ubuntu1804_smoke_test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,32 +153,39 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: macos-installable
-      - name: Build hello.wasm
-        shell: bash
+      - name: Unpack toolchain
         run: |
           set -x
           tar xf $(find . -name "swift-wasm-*.tar.gz" -type f)
-          TOOLCHAIN_PATH=$(find "$PWD" -name "swift-wasm-*" -type d)
+          echo "TOOLCHAIN=$(find "$PWD" -name "swift-wasm-*" -type d)" >> $GITHUB_ENV
+      - name: Build hello.wasm
+        shell: bash
+        run: |
           echo 'print("Hello, world!")' > hello.swift
-          $TOOLCHAIN_PATH/usr/bin/swiftc \
+          $TOOLCHAIN/usr/bin/swiftc \
                 -target wasm32-unknown-wasi \
-                -sdk $TOOLCHAIN_PATH/usr/share/wasi-sysroot \
+                -sdk $TOOLCHAIN/usr/share/wasi-sysroot \
                 hello.swift -o hello.wasm && \
                 echo "Successfully linked hello.wasm"
       - name: Test SwiftPM
         shell: bash
         run: |
           set -x
-          TOOLCHAIN_PATH=$(find "$PWD" -name "swift-wasm-*" -type d)
           mkdir test
           cd test
-          $TOOLCHAIN_PATH/usr/bin/swift package init
-          $TOOLCHAIN_PATH/usr/bin/swift build --triple wasm32-unknown-wasi
+          $TOOLCHAIN/usr/bin/swift package init
+          $TOOLCHAIN/usr/bin/swift build --triple wasm32-unknown-wasi
       - name: Upload hello.wasm compiled with macOS package
         uses: actions/upload-artifact@v1
         with:
           name: macos-hello.wasm
           path: hello.wasm
+      - name: Checkout integration-tests
+        uses: actions/checkout@v2
+        with:
+          repository: swiftwasm/integration-tests
+      - name: Run integration tests
+        run: swift run # Use TOOLCHAIN env value
 
   ubuntu1804_smoke_test:
     name: Run smoke tests on Ubuntu 18.04
@@ -189,32 +196,39 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: ubuntu18.04-installable
-      - name: Build hello.wasm
-        shell: bash
+      - name: Unpack toolchain
         run: |
           set -x
           tar xf $(find . -name "swift-wasm-*.tar.gz" -type f)
-          TOOLCHAIN_PATH=$(find "$PWD" -name "swift-wasm-*" -type d)
+          echo "TOOLCHAIN=$(find "$PWD" -name "swift-wasm-*" -type d)" >> $GITHUB_ENV
+      - name: Build hello.wasm
+        shell: bash
+        run: |
           echo 'print("Hello, world!")' > hello.swift
-          $TOOLCHAIN_PATH/usr/bin/swiftc \
+          $TOOLCHAIN/usr/bin/swiftc \
                 -target wasm32-unknown-wasi \
-                -sdk $TOOLCHAIN_PATH/usr/share/wasi-sysroot \
+                -sdk $TOOLCHAIN/usr/share/wasi-sysroot \
                 hello.swift -o hello.wasm && \
                 echo "Successfully linked hello.wasm"
       - name: Test SwiftPM
         shell: bash
         run: |
           set -x
-          TOOLCHAIN_PATH=$(find "$PWD" -name "swift-wasm-*" -type d)
           mkdir test
           cd test
-          $TOOLCHAIN_PATH/usr/bin/swift package init
-          $TOOLCHAIN_PATH/usr/bin/swift build --triple wasm32-unknown-wasi
+          $TOOLCHAIN/usr/bin/swift package init
+          $TOOLCHAIN/usr/bin/swift build --triple wasm32-unknown-wasi
       - name: Upload hello.wasm compiled with Ubuntu 18.04 package
         uses: actions/upload-artifact@v1
         with:
           name: ubuntu18.04-hello.wasm
           path: hello.wasm
+      - name: Checkout integration-tests
+        uses: actions/checkout@v2
+        with:
+          repository: swiftwasm/integration-tests
+      - name: Run integration tests
+        run: swift run # Use TOOLCHAIN env value
 
   ubuntu2004_smoke_test:
     name: Run smoke tests on Ubuntu 20.04
@@ -225,29 +239,36 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: ubuntu20.04-installable
-      - name: Build hello.wasm
-        shell: bash
+      - name: Unpack toolchain
         run: |
           set -x
           tar xf $(find . -name "swift-wasm-*.tar.gz" -type f)
-          TOOLCHAIN_PATH=$(find "$PWD" -name "swift-wasm-*" -type d)
+          echo "TOOLCHAIN=$(find "$PWD" -name "swift-wasm-*" -type d)" >> $GITHUB_ENV
+      - name: Build hello.wasm
+        shell: bash
+        run: |
           echo 'print("Hello, world!")' > hello.swift
-          $TOOLCHAIN_PATH/usr/bin/swiftc \
+          $TOOLCHAIN/usr/bin/swiftc \
                 -target wasm32-unknown-wasi \
-                -sdk $TOOLCHAIN_PATH/usr/share/wasi-sysroot \
+                -sdk $TOOLCHAIN/usr/share/wasi-sysroot \
                 hello.swift -o hello.wasm && \
                 echo "Successfully linked hello.wasm"
       - name: Test SwiftPM
         shell: bash
         run: |
           set -x
-          TOOLCHAIN_PATH=$(find "$PWD" -name "swift-wasm-*" -type d)
           mkdir test
           cd test
-          $TOOLCHAIN_PATH/usr/bin/swift package init
-          $TOOLCHAIN_PATH/usr/bin/swift build --triple wasm32-unknown-wasi
+          $TOOLCHAIN/usr/bin/swift package init
+          $TOOLCHAIN/usr/bin/swift build --triple wasm32-unknown-wasi
       - name: Upload hello.wasm compiled with Ubuntu 20.04 package
         uses: actions/upload-artifact@v1
         with:
           name: ubuntu20.04-hello.wasm
           path: hello.wasm
+      - name: Checkout integration-tests
+        uses: actions/checkout@v2
+        with:
+          repository: swiftwasm/integration-tests
+      - name: Run integration tests
+        run: swift run # Use TOOLCHAIN env value

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,8 +184,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: swiftwasm/integration-tests
+          path: integration-tests
       - name: Run integration tests
         run: swift run # Use TOOLCHAIN env value
+        working-directory: ${{ github.workspace }}/integration-tests
 
   ubuntu1804_smoke_test:
     name: Run smoke tests on Ubuntu 18.04
@@ -227,8 +229,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: swiftwasm/integration-tests
+          path: integration-tests
       - name: Run integration tests
         run: swift run # Use TOOLCHAIN env value
+        working-directory: ${{ github.workspace }}/integration-tests
 
   ubuntu2004_smoke_test:
     name: Run smoke tests on Ubuntu 20.04
@@ -270,5 +274,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: swiftwasm/integration-tests
+          path: integration-tests
       - name: Run integration tests
         run: swift run # Use TOOLCHAIN env value
+        working-directory: ${{ github.workspace }}/integration-tests

--- a/utils/webassembly/build-foundation.sh
+++ b/utils/webassembly/build-foundation.sh
@@ -20,7 +20,3 @@ cmake -G Ninja \
   
 ninja -v
 ninja -v install
-
-# .swiftdoc and .swiftmodule files should live in `swift`, not in `swift_static`
-mv $DESTINATION_TOOLCHAIN/usr/lib/swift_static/wasi/wasm32/Foundation.swift* \
-  $DESTINATION_TOOLCHAIN/usr/lib/swift/wasi/wasm32

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -115,8 +115,10 @@ merge_toolchains() {
   rsync -v -a "$TARGET_TOOLCHAIN_SDK/usr/bin/" "$DIST_TOOLCHAIN_SDK/usr/bin/"
 
   # Replace absolute sysroot path with relative path
-  sed -i "" -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
-  sed -i "" -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift_static/wasi/wasm32/wasi.modulemap"
+  sed -i.bak -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
+  rm "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
+  sed -i.bak -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift_static/wasi/wasm32/wasi.modulemap"
+  rm "$DIST_TOOLCHAIN_SDK/usr/lib/swift_static/wasi/wasm32/wasi.modulemap"
 }
 
 create_darwin_info_plist() {

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -115,7 +115,7 @@ merge_toolchains() {
   rsync -v -a "$TARGET_TOOLCHAIN_SDK/usr/bin/" "$DIST_TOOLCHAIN_SDK/usr/bin/"
 
   # Replace absolute sysroot path with relative path
-  sed -i -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
+  sed -i "" -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
 }
 
 create_darwin_info_plist() {

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -116,6 +116,7 @@ merge_toolchains() {
 
   # Replace absolute sysroot path with relative path
   sed -i "" -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
+  sed -i "" -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift_static/wasi/wasm32/wasi.modulemap"
 }
 
 create_darwin_info_plist() {

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -116,9 +116,9 @@ merge_toolchains() {
 
   # Replace absolute sysroot path with relative path
   sed -i.bak -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
-  rm "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"
+  rm "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap.bak"
   sed -i.bak -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift_static/wasi/wasm32/wasi.modulemap"
-  rm "$DIST_TOOLCHAIN_SDK/usr/lib/swift_static/wasi/wasm32/wasi.modulemap"
+  rm "$DIST_TOOLCHAIN_SDK/usr/lib/swift_static/wasi/wasm32/wasi.modulemap.bak"
 }
 
 create_darwin_info_plist() {

--- a/utils/webassembly/build-xctest.sh
+++ b/utils/webassembly/build-xctest.sh
@@ -15,7 +15,7 @@ cmake -G Ninja \
   -DWASI_SDK_PATH="$SOURCE_PATH/wasi-sdk" \
   -DBUILD_SHARED_LIBS=OFF \
   -DCMAKE_Swift_COMPILER_FORCED=ON \
-  -DSWIFT_FOUNDATION_PATH=$DESTINATION_TOOLCHAIN/usr/lib/swift/wasi/wasm32 \
+  -DSWIFT_FOUNDATION_PATH=$DESTINATION_TOOLCHAIN/usr/lib/swift_static/wasi/wasm32 \
   "${SOURCE_PATH}/swift-corelibs-xctest"
   
 ninja -v


### PR DESCRIPTION
macOS's `sed` command always requires `-i` option value and `-e` was recognized as backup suffix, so `usr/lib/swift/wasi/wasm32/wasi.modulemap-e` was created in toolchain.