### PR TITLE
Set default sdk value as wasi-sysroot when targeting WASI OS

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1754,6 +1754,13 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
           });
         }
       }
+    } if (OI.SDKPath.empty() && TC.getTriple().isOSWASI()) {
+        llvm::SmallString<128> SDKPath;
+        llvm::sys::path::append(SDKPath, getSwiftProgramPath());
+        llvm::sys::path::remove_filename(SDKPath); // 'swift'
+        llvm::sys::path::remove_filename(SDKPath); // 'bin'
+        llvm::sys::path::append(SDKPath, "share", "wasi-sysroot");
+        OI.SDKPath = SDKPath.str().str();
     }
 
     if (!OI.SDKPath.empty()) {


### PR DESCRIPTION
After this patch, we don't need to pass `-sdk` option explicitly.