### PR TITLE
Use WASI SDK 0.2.2-swiftwasm to fix setjmp headers in 5.3 branch

### DIFF
--- a/utils/webassembly/install-wasi-sdk.sh
+++ b/utils/webassembly/install-wasi-sdk.sh
@@ -6,7 +6,7 @@ SOURCE_PATH="$( cd "$(dirname $0)/../../../" && pwd  )"
 
 cd $SOURCE_PATH
 
-WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.0-swiftwasm/dist-$2-latest.tgz.zip"
+WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.2-swiftwasm/dist-$2.zip"
 
 [ ! -e dist-wasi-sdk.tgz.zip ] && \
   wget -O dist-wasi-sdk.tgz.zip $WASI_SDK_URL

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -53,7 +53,7 @@ fi
 
 cmake --version
 
-$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh linux ubuntu
+$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh linux ubuntu-18.04
 
 # Link wasm32-wasi-unknown to wasm32-wasi because clang finds crt1.o from sysroot
 # with os and environment name `getMultiarchTriple`.

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -22,7 +22,7 @@ cd $SWIFT_PATH
 
 cd $SOURCE_PATH
 
-$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh macos macos
+$SWIFT_PATH/utils/webassembly/install-wasi-sdk.sh macos macos-10.15
 
 # Link sysroot/usr/include to sysroot/include because Darwin sysroot doesn't 
 # find header files in sysroot/include but sysroot/usr/include


### PR DESCRIPTION
WASI SDK 0.2.2-swiftwasm is already used in the `swiftwasm` branch. This makes it easier for us to build OpenCombine and other C++ code when targeting WASI.