### PR TITLE
Fix least valid pointer value

### DIFF
--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -121,6 +121,9 @@ protected:
                                      const JobContext &context) const override;
   InvocationInfo constructInvocation(const StaticLinkJobAction &job,
                                      const JobContext &context) const override;
+  void validateArguments(DiagnosticEngine &diags,
+                         const llvm::opt::ArgList &args,
+                         StringRef defaultTarget) const override;
 
 public:
   WebAssembly(const Driver &D, const llvm::Triple &Triple) : ToolChain(D, Triple) {}

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -140,6 +140,13 @@ static void configureSystemZ(IRGenModule &IGM, const llvm::Triple &triple,
   target.SwiftRetainIgnoresNegativeValues = true;
 }
 
+/// Configures target-specific information for wasm32 platforms.
+static void configureWasm32(IRGenModule &IGM, const llvm::Triple &triple,
+                            SwiftTargetInfo &target) {
+  target.LeastValidPointerValue =
+    SWIFT_ABI_WASM32_LEAST_VALID_POINTER;
+}
+
 /// Configure a default target.
 SwiftTargetInfo::SwiftTargetInfo(
   llvm::Triple::ObjectFormatType outputObjectFormat,
@@ -196,7 +203,9 @@ SwiftTargetInfo SwiftTargetInfo::get(IRGenModule &IGM) {
   case llvm::Triple::systemz:
     configureSystemZ(IGM, triple, target);
     break;
-
+  case llvm::Triple::wasm32:
+    configureWasm32(IGM, triple, target);
+    break;
   default:
     // FIXME: Complain here? Default target info is unlikely to be correct.
     break;

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -190,6 +190,22 @@ static_assert(alignof(HeapObject) == alignof(void*),
 #define _swift_BridgeObject_TaggedPointerBits                                  \
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
 
+#elif defined(__wasm32__)
+extern unsigned char __global_base;
+#define _swift_abi_LeastValidPointerValue                                      \
+  (__swift_uintptr_t) SWIFT_ABI_WASM32_LEAST_VALID_POINTER
+
+#define _swift_abi_SwiftSpareBitsMask                                          \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_SWIFT_SPARE_BITS_MASK
+
+#define _swift_abi_ObjCReservedBitsMask                                        \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
+#define _swift_abi_ObjCReservedLowBits                                         \
+  (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_32
+
 #else
 
 #define _swift_abi_LeastValidPointerValue                                      \

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -192,4 +192,12 @@
 #define SWIFT_ABI_S390X_OBJC_WEAK_REFERENCE_MARKER_VALUE \
   (1<<SWIFT_ABI_S390X_OBJC_NUM_RESERVED_LOW_BITS)
 
+/*********************************** wasm32 ************************************/
+
+// WebAssembly doesn't reserve low addresses But without "extra inhabitants" of
+// the pointer representation, runtime performance and memory footprint are
+// worse. So assume that compiler driver uses wasm-ld and --global-base=1024 to
+// reserve low 1KB.
+#define SWIFT_ABI_WASM32_LEAST_VALID_POINTER 1024
+
 #endif // SWIFT_STDLIB_SHIMS_ABI_SYSTEM_H


### PR DESCRIPTION
WebAssembly doesn't reserve low addresses But without "extra inhabitants" of
the pointer representation, runtime performance and memory footprint are
worse. So assume that compiler driver uses wasm-ld and --global-base=1024 to
reserve low 1KB.

Fix https://github.com/swiftwasm/swift/issues/2223
