### PR TITLE
Do not follow an existing symbolic link when overwriting

### DIFF
--- a/utils/darwin-installer-scripts/postinstall
+++ b/utils/darwin-installer-scripts/postinstall
@@ -13,4 +13,4 @@
 
 INSTALLED_TOOLCHAIN=$2
 
-ln -fs "${INSTALLED_TOOLCHAIN}" "${INSTALLED_TOOLCHAIN%/*}/swift-latest.xctoolchain"
+ln -fhs "${INSTALLED_TOOLCHAIN}" "${INSTALLED_TOOLCHAIN%/*}/swift-latest.xctoolchain"


### PR DESCRIPTION
```
LN(1)                     BSD General Commands Manual                    LN(1)

NAME
     link, ln -- make links
...
     -h    If the target_file or target_dir is a symbolic link, do not follow it.  This is most useful with the -f option, to replace a symlink which may point to a directory.

```

Currently, if there is an existing swift-latest symbolic link pointing `/Toolchains/swift-a.xctoolchain`, the postinstall script creates a symbolic link at `/Toolchains/swift-a.xctoolchain`. If the destination file is a symbolic link, ln default follows it. So need to pass `-h` flag not to let ln to follow link.