### PR TITLE
Enable stdlib thin CMO

### DIFF
--- a/cmake/caches/Runtime-WASI-wasm32.cmake
+++ b/cmake/caches/Runtime-WASI-wasm32.cmake
@@ -22,6 +22,7 @@ set(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY NO CACHE BOOL "")
 # TODO(katei): This should get turned off, as this is not an ABI stable platform.
 # But current CMake build system doesn't support SWIFT_STDLIB_STABLE_ABI=NO
 set(SWIFT_STDLIB_STABLE_ABI YES CACHE BOOL "")
+set(SWIFT_STDLIB_ENABLE_THINCMO YES CACHE BOOL "")
 
 # build with the host compiler
 set(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER YES CACHE BOOL "")

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -238,6 +238,9 @@ public:
   /// Frameworks that we should not autolink against.
   SmallVector<std::string, 1> DisableAutolinkFrameworks;
 
+  /// Disable autolinking swiftCore for stdlib thin CMO
+  unsigned DisableAutolinkStdlib : 1;
+
   /// Print the LLVM inline tree at the end of the LLVM pass pipeline.
   unsigned PrintInlineTree : 1;
 
@@ -351,6 +354,7 @@ public:
         DisableLLVMOptzns(false), DisableSwiftSpecificLLVMOptzns(false),
         DisableLLVMSLPVectorizer(false), Playground(false),
         EmitStackPromotionChecks(false), FunctionSections(false),
+        DisableAutolinkStdlib(false),
         PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
         LLVMLTOKind(IRGenLLVMLTOKind::None), HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -713,6 +713,10 @@ def no_stdlib_rpath: Flag<["-"], "no-stdlib-rpath">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
   HelpText<"Don't add any rpath entries.">;
 
+def no_stdlib_link: Flag<["-"], "no-stdlib-link">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Don't link stdlib.">;
+
 def static_executable : Flag<["-"], "static-executable">,
   HelpText<"Statically link the executable">;
 def no_static_executable : Flag<["-"], "no-static-executable">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -304,6 +304,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   }
 
   addLTOArgs(OI, arguments);
+  inputArgs.AddLastArg(arguments, options::OPT_no_stdlib_link);
 
   // -g implies -enable-anonymous-context-mangled-names, because the extra
   // metadata aids debugging.

--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -163,6 +163,12 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
     llvm::report_fatal_error(linkFile + " not found");
   }
 
+  if (context.Args.hasArg(options::OPT_no_stdlib_link)) {
+    Arguments.push_back("-lswiftStandaloneRuntime");
+  } else {
+    Arguments.push_back("-lswiftCore");
+  }
+
   // Explicitly pass the target to the linker
   Arguments.push_back(
       context.Args.MakeArgString("--target=" + getTriple().str()));

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1553,6 +1553,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
   }
 
+  if (Args.hasArg(OPT_no_stdlib_link)) {
+    Opts.DisableAutolinkStdlib = true;
+  }
+
   if (const Arg *A = Args.getLastArg(options::OPT_sanitize_coverage_EQ)) {
     Opts.SanitizeCoverage =
         parseSanitizerCoverageArgValue(A, Triple, Diags, Opts.Sanitizers);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1220,6 +1220,8 @@ void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
   
   switch (linkLib.getKind()) {
   case LibraryKind::Library: {
+    if (linkLib.getName() == "swiftCore" && IRGen.Opts.DisableAutolinkStdlib)
+      return;
     AutolinkEntries.emplace_back(linkLib);
     break;
   }

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -59,6 +59,10 @@ option(SWIFT_ENABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"
        "${SWIFT_STDLIB_STABLE_ABI}")
 
+option(SWIFT_STDLIB_ENABLE_THINCMO
+       "Generate .swiftmodulesummary and .sib files alongside .swiftmodule files for thin cross module optimization"
+       FALSE)
+
 option(SWIFT_ENABLE_COMPATIBILITY_OVERRIDES
        "Support back-deploying compatibility fixes for newer apps running on older runtimes."
        TRUE)

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -152,6 +152,13 @@ add_swift_target_library(swiftRuntime OBJECT_LIBRARY
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install)
 
+
+add_swift_target_library(swiftStandaloneRuntime STATIC IS_STDLIB
+  INCORPORATE_OBJECT_LIBRARIES
+    swiftRuntime swiftLLVMSupport swiftDemangling swiftStdlibStubs
+  INSTALL_IN_COMPONENT
+    stdlib)
+
 set(ELFISH_SDKS)
 set(COFF_SDKS)
 set(WASM_SDKS)

--- a/utils/webassembly/static-executable-args.lnk
+++ b/utils/webassembly/static-executable-args.lnk
@@ -1,5 +1,4 @@
 -static
--lswiftCore
 -lswiftSwiftOnoneSupport
 -lswiftWasiPthread
 -licuuc


### PR DESCRIPTION
- Embed .swiftmodulesummary and .sib files in our toolchain to enable stdlib thin LTO. 
- Add no-stdlib-link mode to link stdlib object file built by SwiftPM or other external build system using modulesummary.

