### PR TITLE
Add `swiftwasm-release/5.4` to `pull.yml`

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -6,10 +6,19 @@ rules:
   - base: main
     upstream: apple:main
     mergeMethod: hardreset
+
   - base: release/5.3
     upstream: apple:release/5.3
     mergeMethod: hardreset
   - base: swiftwasm-release/5.3
     upstream: release/5.3
     mergeMethod: merge
+
+  - base: release/5.4
+    upstream: apple:release/5.4
+    mergeMethod: hardreset
+  - base: swiftwasm-release/5.4
+    upstream: release/5.4
+    mergeMethod: merge
+
 label: ":arrow_heading_down: Upstream Tracking"

--- a/.github/workflows/manual-distribution.yml
+++ b/.github/workflows/manual-distribution.yml
@@ -45,6 +45,9 @@ jobs:
             "5.3")
               ./utils/webassembly/distribute-latest-toolchain.sh swiftwasm-release/5.3 5.3 "${{ github.event.inputs.toolchain_name }}"
             ;;
+            "5.4")
+              ./utils/webassembly/distribute-latest-toolchain.sh swiftwasm-release/5.4 5.4 "${{ github.event.inputs.toolchain_name }}"
+            ;;
             *)
               echo "Unrecognised release channel: ${{ github.event.inputs.channel }}"
               exit 1

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -37,7 +37,16 @@ jobs:
           DARWIN_TOOLCHAIN_NOTARIZE_EMAIL: ${{ secrets.DARWIN_TOOLCHAIN_NOTARIZE_EMAIL }}
           DARWIN_TOOLCHAIN_NOTARIZE_PASSWORD: ${{ secrets.DARWIN_TOOLCHAIN_NOTARIZE_PASSWORD }}
         if: github.ref == 'refs/heads/swiftwasm'
+
       - run: ./utils/webassembly/distribute-latest-toolchain.sh swiftwasm-release/5.3 5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DARWIN_TOOLCHAIN_APPLICATION_CERT: ${{ secrets.DARWIN_TOOLCHAIN_APPLICATION_CERT }}
+          DARWIN_TOOLCHAIN_INSTALLER_CERT: ${{ secrets.DARWIN_TOOLCHAIN_INSTALLER_CERT }}
+          DARWIN_TOOLCHAIN_NOTARIZE_EMAIL: ${{ secrets.DARWIN_TOOLCHAIN_NOTARIZE_EMAIL }}
+          DARWIN_TOOLCHAIN_NOTARIZE_PASSWORD: ${{ secrets.DARWIN_TOOLCHAIN_NOTARIZE_PASSWORD }}
+
+      - run: ./utils/webassembly/distribute-latest-toolchain.sh swiftwasm-release/5.4 5.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DARWIN_TOOLCHAIN_APPLICATION_CERT: ${{ secrets.DARWIN_TOOLCHAIN_APPLICATION_CERT }}


### PR DESCRIPTION
Now that 5.4 was branched off, it's time for us to start tagging regular snapshots for it. I've already created separate branches in corresponding repositories.