### PR TITLE
Use `pip3` when `pip` is absent in macOS deps script

### DIFF
--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -9,7 +9,6 @@ else
   PIP_COMMAND=pip
 fi
 
-
 $PIP_COMMAND install six
 
 brew install cmake ninja llvm sccache

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-pip install six
+pip3 install six
 
 brew install cmake ninja llvm sccache
 

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -2,7 +2,15 @@
 
 set -ex
 
-pip3 install six
+if ! command -v pip &> /dev/null
+then
+  PIP_COMMAND=pip3
+else
+  PIP_COMMAND=pip
+fi
+
+
+$PIP_COMMAND install six
 
 brew install cmake ninja llvm sccache
 


### PR DESCRIPTION
For some reason plain `pip` no longer works for me on Big Sur, I wonder if `pip3` would be a more reliable invocation here.