### PR TITLE
Avoid reinstalling SDK archives if already present

### DIFF
--- a/utils/webassembly/install-build-sdk.sh
+++ b/utils/webassembly/install-build-sdk.sh
@@ -40,6 +40,14 @@ pushd "$workdir"
 
 mkdir -p "$BUILD_SDK_PATH"
 
-install_libxml2
-install_icu
-install_wasi-sdk
+if [ ! -e "$BUILD_SDK_PATH/libxml2" ]; then
+  install_libxml2
+fi
+
+if [ ! -e "$BUILD_SDK_PATH/icu" ]; then
+  install_icu
+fi
+
+if [ ! -e "$BUILD_SDK_PATH/wasi-sdk" ]; then
+  install_wasi-sdk
+fi


### PR DESCRIPTION
Currently `ci.sh` redownloads and reinstalls SDK archives on every run even if those are present. This is especially annoying when on a slow network where these downloads may take a long time. Let's avoid redownloading these archives if their contents is already present.