### PR TITLE
Check if `pip` is installed in macOS `install-dependencies.sh`

### DIFF
--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-pip install six
+if [ -x "$(command -v pip)" ]; then
+  pip install six
+fi
 pip3 install six
 
 brew install cmake ninja llvm sccache


### PR DESCRIPTION
`pip` is not always installed on macOS, and `pip3` should be enough to build. Let's make the use of `pip` conditional.