### PR TITLE
Switch to upstream SwiftPM repository

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -23,7 +23,7 @@
         "swift-tools-support-core": {
             "remote": { "id": "apple/swift-tools-support-core" } },
         "swiftpm": {
-            "remote": { "id": "swiftwasm/swift-package-manager" } },
+            "remote": { "id": "apple/swift-package-manager" } },
         "swift-syntax": {
             "remote": { "id": "apple/swift-syntax" } },
         "swift-system": {
@@ -73,7 +73,7 @@
                 "cmark": "main",
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
-                "swiftpm": "swiftwasm",
+                "swiftpm": "main",
                 "swift-argument-parser": "0.4.3",
                 "swift-crypto": "1.1.5",
                 "swift-driver": "main",


### PR DESCRIPTION
Our fork no longer differs from the upstream SwiftPM repo, let's use that directly.