### PR TITLE
Remove references to thread sanitizer in Wasm toolchain

### DIFF
--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -169,12 +169,6 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
   if (job.getKind() == LinkKind::Executable && context.OI.SelectedSanitizers) {
     Arguments.push_back(context.Args.MakeArgString(
         "-fsanitize=" + getSanitizerList(context.OI.SelectedSanitizers)));
-
-    // The TSan runtime depends on the blocks runtime and libdispatch.
-    if (context.OI.SelectedSanitizers & SanitizerKind::Thread) {
-      Arguments.push_back("-lBlocksRuntime");
-      Arguments.push_back("-ldispatch");
-    }
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {


### PR DESCRIPTION
Cleaning some of the toolchain code before submitting it upstream for review.