### PR TITLE
Remove unused headers from WebAssemblyToolchains

### DIFF
--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -14,11 +14,9 @@
 
 #include "swift/ABI/System.h"
 #include "swift/AST/DiagnosticsDriver.h"
-#include "swift/Basic/Dwarf.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/Range.h"
-#include "swift/Basic/TaskQueue.h"
 #include "swift/Config.h"
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Driver.h"


### PR DESCRIPTION
Cleaning up driver sources before submitting changes upstream.