### PR TITLE
Revert unrelated change to `ImageInspectionCommon.h`

### DIFF
--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -41,7 +41,7 @@
 
 #else
 
-#if defined(__ELF__) || defined(__wasm__)
+#if defined(__ELF__)
 #define SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING "swift_reflection_metadata_magic_string"
 #endif // defined(__ELF__)
 

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -18,7 +18,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#if defined(__ELF__) || defined(__wasm__)
+#if defined(__ELF__)
 
 #include "../SwiftShims/MetadataSections.h"
 #include "ImageInspection.h"


### PR DESCRIPTION
Cleaning up the diff in the process of submitting parts of it upstream.