### PR TITLE
runtime: move Wasm code to ImageInspectionWasm.cpp

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -53,6 +53,7 @@ set(swift_runtime_sources
     ImageInspectionELF.cpp
     ImageInspectionCOFF.cpp
     ImageInspectionStatic.cpp
+    ImageInspectionWasm.cpp
     KeyPaths.cpp
     KnownMetadata.cpp
     Metadata.cpp
@@ -123,7 +124,7 @@ foreach(sdk IN LISTS SWIFT_SDKS)
     set(image_inspection_shared_file ImageInspectionELF.cpp)
   elseif(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "WASI")
     set(image_inspection_shared_sdk "${sdk}")
-    set(image_inspection_shared_file ImageInspectionELF.cpp)
+    set(image_inspection_shared_file ImageInspectionWasm.cpp)
     # Set default arch
     set(primary_arch "wasm32")
   endif()

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !defined(__ELF__) && !defined(__MACH__) && !defined(__wasm__)
+#if !defined(__ELF__) && !defined(__MACH__)
 
 #include "ImageInspection.h"
 

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -18,7 +18,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#if defined(__ELF__) || defined(__wasm__)
+#if defined(__ELF__)
 
 #include "../SwiftShims/MetadataSections.h"
 #include "ImageInspection.h"

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -22,14 +22,11 @@
 
 #include "../SwiftShims/MetadataSections.h"
 #include "ImageInspection.h"
-#ifndef __wasm__
 #include <dlfcn.h>
-#endif
 
 using namespace swift;
 
 int swift::lookupSymbol(const void *address, SymbolInfo *info) {
-#ifndef __wasm__
   Dl_info dlinfo;
   if (dladdr(address, &dlinfo) == 0) {
     return 0;
@@ -40,9 +37,6 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
   info->symbolName.reset(dlinfo.dli_sname);
   info->symbolAddress = dlinfo.dli_saddr;
   return 1;
-#else
-  return 0;
-#endif
 }
 
 #endif // defined(__ELF__)

--- a/stdlib/public/runtime/ImageInspectionWasm.cpp
+++ b/stdlib/public/runtime/ImageInspectionWasm.cpp
@@ -1,0 +1,30 @@
+//===--- ImageInspectionStatic.cpp - image inspection for static stdlib ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// Implementation of ImageInspection for WebAssembly.
+///
+//===----------------------------------------------------------------------===//
+
+#if defined(__wasm__)
+
+#include "../SwiftShims/MetadataSections.h"
+#include "ImageInspection.h"
+
+using namespace swift;
+
+int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+  return 0;
+}
+
+#endif // defined(__wasm__)


### PR DESCRIPTION
Image inspection code on Wasm is different enough from ELF code. It makes sense to create a separate file for it. This is also likely to be required by upstream reviewers.