### PR TITLE
SILFunctionExtractor: remove unused Wasm check

### DIFF
--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -254,8 +254,6 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().DisableAvailabilityChecking = true;
   Invocation.getLangOptions().EnableAccessControl = false;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
-  if (Invocation.getLangOptions().Target.isOSBinFormatWasm())
-    Invocation.getLangOptions().EnableObjCInterop = false;
 
   if (EnableObjCInterop == llvm::cl::BOU_UNSET) {
     Invocation.getLangOptions().EnableObjCInterop =


### PR DESCRIPTION
This check is no longer needed since Wasm handling was addressed upstream in https://github.com/apple/swift/pull/31920