### PR TITLE
Update checkout config to build with upstream LLVM

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -100,7 +100,6 @@ jobs:
       - name: Check Xcode version
         if: ${{ startsWith(matrix.build_os, 'macos-') }}
         run: |
-          rm -rf llvm-project
           xcodebuild -version
 
       - uses: actions/cache@v1

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Check Xcode version
         if: ${{ startsWith(matrix.build_os, 'macos-') }}
         run: |
+          cd llvm-project && git remote add swiftwasm git@github.com:swiftwasm/llvm-project.git
           xcodebuild -version
 
       - uses: actions/cache@v1

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -100,7 +100,6 @@ jobs:
       - name: Check Xcode version
         if: ${{ startsWith(matrix.build_os, 'macos-') }}
         run: |
-          cd llvm-project && git remote rm swiftwasm && git remote add swiftwasm https://github.com/swiftwasm/llvm-project.git && git fetch swiftwasm
           xcodebuild -version
 
       - uses: actions/cache@v1

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Check Xcode version
         if: ${{ startsWith(matrix.build_os, 'macos-') }}
         run: |
-          cd llvm-project && git remote add swiftwasm https://github.com/swiftwasm/llvm-project.git && git fetch swiftwasm
+          cd llvm-project && git remote rm swiftwasm && git remote add swiftwasm https://github.com/swiftwasm/llvm-project.git && git fetch swiftwasm
           xcodebuild -version
 
       - uses: actions/cache@v1

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Check Xcode version
         if: ${{ startsWith(matrix.build_os, 'macos-') }}
         run: |
+          rm -rf llvm-project
           xcodebuild -version
 
       - uses: actions/cache@v1

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Check Xcode version
         if: ${{ startsWith(matrix.build_os, 'macos-') }}
         run: |
-          cd llvm-project && git remote add swiftwasm git@github.com:swiftwasm/llvm-project.git
+          cd llvm-project && git remote add swiftwasm https://github.com/swiftwasm/llvm-project.git && git fetch swiftwasm
           xcodebuild -version
 
       - uses: actions/cache@v1

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -61,14 +61,14 @@
         "swift-installer-scripts": {
             "remote": { "id": "apple/swift-installer-scripts" } },
         "llvm-project": {
-            "remote": { "id": "swiftwasm/llvm-project" } }
+            "remote": { "id": "apple/llvm-project" } }
     },
     "default-branch-scheme": "wasm",
     "branch-schemes": {
         "wasm": {
             "aliases": ["wasm", "swiftwasm"],
             "repos": {
-                "llvm-project": "swiftwasm-stable/20210726",
+                "llvm-project": "stable/20210726",
                 "swift": "swiftwasm",
                 "cmark": "main",
                 "llbuild": "main",
@@ -91,30 +91,6 @@
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",
                 "swift-format": "main"
-            }
-        },
-        "wasm/5.3": {
-            "aliases": ["wasm/5.3", "swiftwasm-release/5.3"],
-            "repos": {
-                "llvm-project": "swiftwasm-release/5.3",
-                "swift": "swiftwasm-release/5.3",
-                "cmark": "release/5.3",
-                "llbuild": "release/5.3",
-                "swift-tools-support-core": "release/5.3",
-                "swiftpm": "swiftwasm-release/5.3",
-                "swift-syntax": "release/5.3",
-                "swift-stress-tester": "release/5.3",
-                "swift-corelibs-xctest": "release/5.3",
-                "swift-corelibs-foundation": "release/5.3",
-                "swift-corelibs-libdispatch": "release/5.3",
-                "swift-integration-tests": "release/5.3",
-                "swift-xcode-playground-support": "release/5.3",
-                "ninja": "release",
-                "icu": "release-65-1",
-                "cmake": "v3.16.5",               
-                "indexstore-db": "release/5.3",
-                "sourcekit-lsp": "release/5.3",
-                "swift-format": "master"
             }
         },
        "main": {


### PR DESCRIPTION
As previously announced by @kateinoigakukun:
>The last required commit for swiftwasm has been cherry-picked to the swift's llvm branch! https://github.com/apple/llvm-project/pull/3451
>We no longer need to maintain our llvm downstream fork