### PR TITLE
Exit the distribution script on notarization failure

### DIFF
--- a/utils/webassembly/distribute-latest-toolchain.sh
+++ b/utils/webassembly/distribute-latest-toolchain.sh
@@ -159,6 +159,7 @@ create_installer() {
     xcrun stapler staple "${darwin_toolchain_installer_package}"
   else
     echo "Failed to notarize the toolchain $darwin_toolchain_installer_package: $request_status"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
This will prevent the script from uploading incorrectly signed packages to GitHub releases.