### PR TITLE
Bump CMake on Linux to 3.22.1, support aarch64

### DIFF
--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -43,7 +43,7 @@ fi
 cd $SOURCE_PATH
 
 if [ -z $(which cmake) ]; then
-  wget -O install_cmake.sh "https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2-Linux-x86_64.sh"
+  wget -O install_cmake.sh "https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-$(uname -m).sh"
   chmod +x install_cmake.sh
   sudo mkdir -p /opt/cmake
   sudo ./install_cmake.sh --skip-license --prefix=/opt/cmake


### PR DESCRIPTION
Upstream `main` recently started requiring CMake 3.19 or later. Also, we shouldn't assume Linux is always x86_64, I'm currently trying to build on aarch64.