### PR TITLE
Add `amazonlinux2_x86_64` target to GHA CI runs

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -30,7 +30,7 @@ jobs:
             run_full_test: false
             run_e2e_test: true
             build_hello_wasm: true
-            clean_build_dir: false
+            clean_build_dir: true
 
           - build_os: ubuntu-18.04
             agent_query: ubuntu-18.04

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -23,6 +23,15 @@ jobs:
     strategy:
       matrix:
         include:
+          - build_os: amazon-linux-2
+            agent_query: [AmazonLinux2, X64]
+            target: amazonlinux2_x86_64
+            run_stdlib_test: true
+            run_full_test: false
+            run_e2e_test: true
+            build_hello_wasm: true
+            clean_build_dir: false
+
           - build_os: ubuntu-18.04
             agent_query: ubuntu-18.04
             target: ubuntu18.04_x86_64
@@ -125,7 +134,7 @@ jobs:
         run: |
 
           case "${{ matrix.target }}" in
-            "ubuntu20.04_x86_64" | "ubuntu18.04_x86_64" | "macos_x86_64" | "macos_arm64")
+            "amazonlinux2_x86_64" | "ubuntu20.04_x86_64" | "ubuntu18.04_x86_64" | "macos_x86_64" | "macos_arm64")
               ./swift/utils/webassembly/ci.sh
             ;;
             *)

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -26,7 +26,7 @@ jobs:
           - build_os: amazon-linux-2
             agent_query: [AmazonLinux2, X64]
             target: amazonlinux2_x86_64
-            run_stdlib_test: true
+            run_stdlib_test: false
             run_full_test: false
             run_e2e_test: true
             build_hello_wasm: true

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -28,7 +28,7 @@ jobs:
             target: amazonlinux2_x86_64
             run_stdlib_test: false
             run_full_test: false
-            run_e2e_test: true
+            run_e2e_test: false
             build_hello_wasm: true
             clean_build_dir: true
 

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -3,34 +3,35 @@
 set -ex
 
 if [[ "$(cat /etc/system-release)" == *"Amazon Linux release 2"* ]]; then
-  sudo yum -y install \
-    clang            \
-    cmake            \
-    curl-devel       \
-    gcc-c++          \
-    git              \
-    glibc-static     \
-    libbsd-devel     \
-    libedit-devel    \
-    libicu-devel     \
-    libuuid-devel    \
-    libxml2-devel    \
-    ncurses-devel    \
-    ninja-build      \
-    pexpect          \
-    pkgconfig        \
-    procps-ng        \
-    python           \
-    python-devel     \
-    python-pkgconfig \
-    python-six       \
-    python3-devel    \
-    rsync            \
-    sqlite-devel     \
-    swig             \
-    tzdata           \
-    uuid-devel       \
-    wget             \
+  sudo yum -y install   \
+    clang               \
+    cmake               \
+    curl-devel          \
+    gcc-c++             \
+    git                 \
+    glibc-static        \
+    libbsd-devel        \
+    libedit-devel       \
+    libicu-devel        \
+    libuuid-devel       \
+    libxml2-devel       \
+    ncurses-compat-libs \
+    ncurses-devel       \
+    ninja-build         \
+    pexpect             \
+    pkgconfig           \
+    procps-ng           \
+    python              \
+    python-devel        \
+    python-pkgconfig    \
+    python-six          \
+    python3-devel       \
+    rsync               \
+    sqlite-devel        \
+    swig                \
+    tzdata              \
+    uuid-devel          \
+    wget                \
     which
 
   if [ ! -e /usr/local/bin/ninja ]; then

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -72,7 +72,7 @@ cd $SWIFT_PATH
 
 # Install wasmer
 # FIXME: Wasmer doesn't support linux-aarch64, consider using a different WASI-compatible runtime.
-if [ "$(uname -m)" == "aarch64" ]; then
+if [ "$(uname -m)" != "aarch64" ]; then
   if [ ! -e ~/.wasmer/bin/wasmer ]; then
     curl https://get.wasmer.io -sSfL | sh
   fi

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -71,9 +71,11 @@ cd $SWIFT_PATH
 ./utils/update-checkout --clone --scheme wasm --skip-repository swift
 
 # Install wasmer
-
-if [ ! -e ~/.wasmer/bin/wasmer ]; then
-  curl https://get.wasmer.io -sSfL | sh
+# FIXME: Wasmer doesn't support linux-aarch64, consider using a different WASI-compatible runtime.
+if [ "$(uname -m)" == "aarch64" ]; then
+  if [ ! -e ~/.wasmer/bin/wasmer ]; then
+    curl https://get.wasmer.io -sSfL | sh
+  fi
 fi
 
 cd $SOURCE_PATH

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -5,7 +5,6 @@ set -ex
 if [[ "$(cat /etc/system-release)" == *"Amazon Linux release 2"* ]]; then
   sudo yum -y install   \
     clang               \
-    cmake               \
     curl-devel          \
     gcc-c++             \
     git                 \

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -2,31 +2,65 @@
 
 set -ex
 
-sudo apt update
+if [[ "$(cat /etc/system-release)" == *"Amazon Linux release 2"* ]]; then
+  sudo yum -y install \
+    clang            \
+    cmake            \
+    curl-devel       \
+    gcc-c++          \
+    git              \
+    glibc-static     \
+    libbsd-devel     \
+    libedit-devel    \
+    libicu-devel     \
+    libuuid-devel    \
+    libxml2-devel    \
+    ncurses-devel    \
+    ninja-build      \
+    pexpect          \
+    pkgconfig        \
+    procps-ng        \
+    python           \
+    python-devel     \
+    python-pkgconfig \
+    python-six       \
+    python3-devel    \
+    rsync            \
+    sqlite-devel     \
+    swig             \
+    tzdata           \
+    uuid-devel       \
+    wget             \
+    which
 
-if [ $(grep RELEASE /etc/lsb-release) == "DISTRIB_RELEASE=18.04" ]; then
-  sudo apt install -y \
-    git ninja-build clang-10 python python-six \
-    uuid-dev libicu-dev icu-devtools libbsd-dev \
-    libedit-dev libxml2-dev libsqlite3-dev swig \
-    libpython-dev libncurses5 libncurses5-dev pkg-config \
-    libblocksruntime-dev libcurl4-openssl-dev \
-    make systemtap-sdt-dev tzdata rsync wget llvm-10 zip unzip
-  sudo ln -s -f /usr/bin/clang-10 /usr/bin/clang
-  sudo ln -s -f /usr/bin/clang++-10 /usr/bin/clang++
-elif [ $(grep RELEASE /etc/lsb-release) == "DISTRIB_RELEASE=20.04" ]; then
-  sudo apt install -y \
-    git ninja-build clang python python-six \
-    uuid-dev libicu-dev icu-devtools libbsd-dev \
-    libedit-dev libxml2-dev libsqlite3-dev swig \
-    libpython2-dev libncurses5 libncurses5-dev pkg-config \
-    libblocksruntime-dev libcurl4-openssl-dev \
-    make systemtap-sdt-dev tzdata rsync wget llvm zip unzip
+  sudo ln -s /usr/bin/ninja-build /usr/local/bin/ninja
 else
-  echo "Unknown Ubuntu version"
-  exit 1
+  sudo apt update
+
+  if [ $(grep RELEASE /etc/lsb-release) == "DISTRIB_RELEASE=18.04" ]; then
+    sudo apt install -y \
+      git ninja-build clang-10 python python-six \
+      uuid-dev libicu-dev icu-devtools libbsd-dev \
+      libedit-dev libxml2-dev libsqlite3-dev swig \
+      libpython-dev libncurses5 libncurses5-dev pkg-config \
+      libblocksruntime-dev libcurl4-openssl-dev \
+      make systemtap-sdt-dev tzdata rsync wget llvm-10 zip unzip
+    sudo ln -s -f /usr/bin/clang-10 /usr/bin/clang
+    sudo ln -s -f /usr/bin/clang++-10 /usr/bin/clang++
+  elif [ $(grep RELEASE /etc/lsb-release) == "DISTRIB_RELEASE=20.04" ]; then
+    sudo apt install -y \
+      git ninja-build clang python python-six \
+      uuid-dev libicu-dev icu-devtools libbsd-dev \
+      libedit-dev libxml2-dev libsqlite3-dev swig \
+      libpython2-dev libncurses5 libncurses5-dev pkg-config \
+      libblocksruntime-dev libcurl4-openssl-dev \
+      make systemtap-sdt-dev tzdata rsync wget llvm zip unzip
+  else
+    echo "Unknown Ubuntu version"
+    exit 1
+  fi
+  sudo apt clean
 fi
-sudo apt clean
 
 SOURCE_PATH="$( cd "$(dirname $0)/../../../.." && pwd )" 
 SWIFT_PATH=$SOURCE_PATH/swift

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -33,7 +33,9 @@ if [[ "$(cat /etc/system-release)" == *"Amazon Linux release 2"* ]]; then
     wget             \
     which
 
-  sudo ln -s /usr/bin/ninja-build /usr/local/bin/ninja
+  if [ ! -e /usr/local/bin/ninja ]; then
+    sudo ln -s /usr/bin/ninja-build /usr/local/bin/ninja
+  fi
 else
   sudo apt update
 


### PR DESCRIPTION
This should be squash-merged only after https://github.com/swiftwasm/swift/pull/4150 is merged to prevent duplication of commits, which are shared between these PRs.

Fully implements https://github.com/swiftwasm/swift/issues/2318.

Distribution build can now complete successfully in this configuration, but I had to disable stdlib tests due to https://github.com/swiftwasm/swift/issues/4152.