### PR TITLE
Pin Wasmer version to prevent test failures

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -93,6 +93,8 @@
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
                 "swift-argument-parser": "1.0.1",
+                "swift-atomics": "1.0.2",
+                "swift-collections": "1.0.1",
                 "swift-crypto": "1.1.5",
                 "swift-driver": "main",
                 "swift-syntax": "main",

--- a/utils/webassembly/linux/install-dependencies.sh
+++ b/utils/webassembly/linux/install-dependencies.sh
@@ -74,7 +74,7 @@ cd $SWIFT_PATH
 # FIXME: Wasmer doesn't support linux-aarch64, consider using a different WASI-compatible runtime.
 if [ "$(uname -m)" != "aarch64" ]; then
   if [ ! -e ~/.wasmer/bin/wasmer ]; then
-    curl https://get.wasmer.io -sSfL | sh
+    curl https://get.wasmer.io -sSfL | sh -s "2.1.1"
   fi
 fi
 

--- a/utils/webassembly/macos/install-dependencies.sh
+++ b/utils/webassembly/macos/install-dependencies.sh
@@ -11,7 +11,7 @@ brew install cmake ninja llvm sccache
 
 # Install latest wasmer
 if [ ! -e ~/.wasmer/bin/wasmer ]; then
-  curl https://get.wasmer.io -sSfL | sh
+  curl https://get.wasmer.io -sSfL | sh -s "2.1.1"
 fi
 
 SOURCE_PATH="$(cd "$(dirname $0)/../../../../" && pwd)"


### PR DESCRIPTION
Apparently, Wasmer 2.2.0-rc1 is causing our tests to fail, let's pin it to 2.1.1 on both Linux and macOS.