### PR TITLE
Concurrency: fix async let argument mismatch crash

### DIFF
--- a/include/swift/ABI/Executor.h
+++ b/include/swift/ABI/Executor.h
@@ -141,7 +141,7 @@ using JobInvokeFunction =
 
 using TaskContinuationFunction =
   SWIFT_CC(swiftasync)
-  void (SWIFT_ASYNC_CONTEXT AsyncContext *);
+  void (SWIFT_ASYNC_CONTEXT AsyncContext *, swift::SwiftError *);
 
 using ThrowingTaskFutureWaitContinuationFunction =
   SWIFT_CC(swiftasync)

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -287,7 +287,7 @@ public:
   /// runInExecutorContext.
   SWIFT_CC(swiftasync)
   void runInFullyEstablishedContext() {
-    return ResumeTask(ResumeContext); // 'return' forces tail call
+    return ResumeTask(ResumeContext, nullptr); // 'return' forces tail call
   }
 
   /// A task can have the following states:
@@ -655,7 +655,7 @@ public:
   void resumeParent() {
     // TODO: destroy context before returning?
     // FIXME: force tail call
-    return ResumeParent(Parent);
+    return ResumeParent(Parent, nullptr);
   }
 };
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1732,7 +1732,7 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
   // we can just immediately continue running with the resume function
   // we were passed in.
   if (!currentExecutor.mustSwitchToRun(newExecutor)) {
-    return resumeFunction(resumeContext); // 'return' forces tail call
+    return resumeFunction(resumeContext, nullptr); // 'return' forces tail call
   }
 
   // Park the task for simplicity instead of trying to thread the

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -233,7 +233,7 @@ static void swift_asyncLet_getImpl(SWIFT_ASYNC_CONTEXT AsyncContext *callerConte
                                    AsyncContext *callContext) {
   // Don't need to do anything if the result buffer is already populated.
   if (asImpl(alet)->hasResultInBuffer()) {
-    return resumeFunction(callerContext);
+    return resumeFunction(callerContext, nullptr);
   }
 
   // Mark the async let as having its result populated.
@@ -433,7 +433,7 @@ static void swift_asyncLet_finishImpl(SWIFT_ASYNC_CONTEXT AsyncContext *callerCo
 
 SWIFT_CC(swiftasync)
 static void _asyncLet_consume_continuation(
-                                SWIFT_ASYNC_CONTEXT AsyncContext *callContext) {
+                                SWIFT_ASYNC_CONTEXT AsyncContext *callContext, swift::SwiftError *error) {
   // Retrieve the async let pointer from the context.
   auto continuationContext
     = reinterpret_cast<AsyncLetContinuationContext*>(callContext);

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -656,7 +656,7 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
 
 SWIFT_CC(swiftasync)
 static void
-task_group_wait_resume_adapter(SWIFT_ASYNC_CONTEXT AsyncContext *_context) {
+task_group_wait_resume_adapter(SWIFT_ASYNC_CONTEXT AsyncContext *_context, swift::SwiftError *error) {
 
   auto context = static_cast<TaskFutureWaitAsyncContext *>(_context);
   auto resumeWithError =

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -120,7 +120,7 @@ class TaskContinuationFromLambda {
 
   SWIFT_CC(swiftasync)
   static void invoke(SWIFT_ASYNC_CONTEXT AsyncContext *context, SWIFT_CONTEXT HeapObject *) {
-    return (*lambdaStorage)(static_cast<Context*>(context));
+    return (*lambdaStorage)(static_cast<Context*>(context), nullptr);
   }
 
 public:
@@ -275,7 +275,7 @@ TEST(ActorTest, actorSwitch) {
     auto actor = createActor();
     auto task0 = createTaskStoring(JobPriority::Default,
                                    (AsyncTask*) nullptr, actor,
-      [](Context *context) SWIFT_CC(swiftasync) {
+      [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
         EXPECT_PROGRESS(1);
         EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
         EXPECT_EQ(nullptr, context->get<0>());
@@ -317,7 +317,7 @@ TEST(ActorTest, actorContention) {
 
     auto task0 = createTaskStoring(JobPriority::Default,
                                    (AsyncTask*) nullptr, actor,
-      [](Context *context) SWIFT_CC(swiftasync) {
+      [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
         EXPECT_PROGRESS(1);
         EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
         EXPECT_EQ(nullptr, context->get<0>());
@@ -326,7 +326,7 @@ TEST(ActorTest, actorContention) {
         std::get<0>(context->values) = task;
 
         parkTask(task, context,
-          [](Context *context) SWIFT_CC(swiftasync) {
+          [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
             EXPECT_PROGRESS(2);
             auto executor = swift_task_getCurrentExecutor();
             EXPECT_FALSE(executor.isGeneric());
@@ -335,7 +335,7 @@ TEST(ActorTest, actorContention) {
             auto task = swift_task_getCurrent();
             EXPECT_EQ(task, context->get<0>());
             parkTask(task, context,
-              [](Context *context) SWIFT_CC(swiftasync) {
+              [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
                 EXPECT_PROGRESS(4);
                 EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
                 EXPECT_EQ(swift_task_getCurrent(), context->get<0>());
@@ -350,7 +350,7 @@ TEST(ActorTest, actorContention) {
 
     auto task1 = createTaskStoring(JobPriority::Background,
                                    (AsyncTask*) nullptr, actor,
-      [](Context *context) SWIFT_CC(swiftasync) {
+      [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
         EXPECT_PROGRESS(3);
         auto executor = swift_task_getCurrentExecutor();
         EXPECT_FALSE(executor.isGeneric());
@@ -361,7 +361,7 @@ TEST(ActorTest, actorContention) {
         std::get<0>(context->values) = task;
 
         parkTask(task, context,
-          [](Context *context) SWIFT_CC(swiftasync) {
+          [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
             EXPECT_PROGRESS(5);
             EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
             EXPECT_EQ(swift_task_getCurrent(), context->get<0>());

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -282,7 +282,7 @@ TEST(ActorTest, actorSwitch) {
         std::get<0>(context->values) = swift_task_getCurrent();
 
         auto continuation = prepareContinuation<Context>(
-          [](Context *context) SWIFT_CC(swiftasync) {
+          [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
             EXPECT_PROGRESS(2);
             auto executor = swift_task_getCurrentExecutor();
             EXPECT_FALSE(executor.isGeneric());
@@ -290,7 +290,7 @@ TEST(ActorTest, actorSwitch) {
                       executor);
             EXPECT_EQ(swift_task_getCurrent(), context->get<0>());
             auto continuation = prepareContinuation<Context>(
-              [](Context *context) SWIFT_CC(swiftasync) {
+              [](Context *context, swift::SwiftError *error) SWIFT_CC(swiftasync) {
                 EXPECT_PROGRESS(3);
                 EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
                 EXPECT_EQ(swift_task_getCurrent(), context->get<0>());


### PR DESCRIPTION
Resolves https://github.com/swiftwasm/swift/issues/4250.