### PR TITLE
Update wasi-sdk to 4 to 14.0

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -129,11 +129,12 @@ jobs:
           restore-keys: |
             ${{ matrix.target }}-sccache-v11-
 
-      - name: Clean stdlib build directory
+      - name: Clean build directory
         if: ${{ matrix.clean_build_dir }}
         run: |
           rm -rf ${{ github.workspace }}/target-build \
             ${{ github.workspace }}/host-build \
+            ${{ github.workspace }}/build-sdk \
             ${{ github.workspace }}/host-toolchain-sdk \
             ${{ github.workspace }}/dist-toolchain-sdk
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -690,7 +690,10 @@ importer::getNormalInvocationArguments(
     }
 
     if (triple.isOSWASI()) {
-      invocationArgStrs.insert(invocationArgStrs.end(), {"-D_WASI_EMULATED_MMAN"});
+      invocationArgStrs.insert(invocationArgStrs.end(),
+                               {"-D_WASI_EMULATED_MMAN",
+                                "-D_WASI_EMULATED_SIGNAL",
+                                "-D_WASI_EMULATED_PROCESS_CLOCKS"});
       SmallString<128> buffer;
       if (auto path = getWasiLibcModuleMapPath(searchPathOpts, triple, buffer)) {
         invocationArgStrs.push_back((Twine("-fmodule-map-file=") + *path).str());

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -288,7 +288,7 @@ function(_add_target_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WASI")
-    list(APPEND result "-D_WASI_EMULATED_MMAN")
+    list(APPEND result "-D_WASI_EMULATED_MMAN" "-D_WASI_EMULATED_SIGNAL" "-D_WASI_EMULATED_PROCESS_CLOCKS")
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "LINUX")
@@ -296,10 +296,6 @@ function(_add_target_variant_c_compile_flags)
       # this is the minimum architecture that supports 16 byte CAS, which is necessary to avoid a dependency to libatomic
       list(APPEND result "-march=core2")
     endif()
-  endif()
-
-  if("${CFLAGS_SDK}" STREQUAL "WASI")
-    list(APPEND result "-D_WASI_EMULATED_MMAN")
   endif()
 
   if(NOT SWIFT_STDLIB_ENABLE_OBJC_INTEROP)

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -243,7 +243,7 @@ function(_add_target_variant_swift_compile_flags
   endif()
 
   if("${sdk}" STREQUAL "WASI")
-    list(APPEND result "-Xcc" "-D_WASI_EMULATED_MMAN")
+    list(APPEND result "-Xcc" "-D_WASI_EMULATED_MMAN" "-Xcc" "-D_WASI_EMULATED_SIGNAL" "-Xcc" "-D_WASI_EMULATED_PROCESS_CLOCKS")
   endif()
 
   if(NOT BUILD_STANDALONE)

--- a/utils/webassembly/build-presets.ini
+++ b/utils/webassembly/build-presets.ini
@@ -24,6 +24,7 @@ install-prefix=/usr
 [preset: webassembly-host]
 
 mixin-preset=webassembly
+sccache
 extra-cmake-options=
     -DSWIFT_BUILD_SOURCEKIT=FALSE
     -DSWIFT_ENABLE_SOURCEKIT_TESTS=FALSE

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -5,8 +5,7 @@ SOURCE_PATH="$(cd "$(dirname "$0")/../../.." && pwd)"
 UTILS_PATH="$(cd "$(dirname "$0")" && pwd)"
 
 BUILD_SDK_PATH="$SOURCE_PATH/build-sdk"
-WASI_SDK_PATH="$BUILD_SDK_PATH/wasi-sdk"
-WASI_SYSROOT_PATH="$WASI_SDK_PATH/share/wasi-sysroot"
+WASI_SYSROOT_PATH="$BUILD_SDK_PATH/wasi-sysroot"
 
 case $(uname -s) in
   Darwin)
@@ -155,7 +154,7 @@ build_target_toolchain() {
 
 embed_wasi_sysroot() {
   # Merge wasi-sdk and the toolchain
-  cp -r "$WASI_SDK_PATH/share/wasi-sysroot" "$DIST_TOOLCHAIN_SDK/usr/share"
+  cp -r "$WASI_SYSROOT_PATH" "$DIST_TOOLCHAIN_SDK/usr/share"
 
   # Replace absolute sysroot path with relative path
   sed -i.bak -e "s@\".*/include@\"../../../../share/wasi-sysroot/include@g" "$DIST_TOOLCHAIN_SDK/usr/lib/swift/wasi/wasm32/wasi.modulemap"

--- a/utils/webassembly/install-build-sdk.sh
+++ b/utils/webassembly/install-build-sdk.sh
@@ -19,20 +19,12 @@ install_icu() {
   mv icu_out "$BUILD_SDK_PATH/icu"
 }
 
-install_wasi-sdk() {
-  # We only use wasi-sysroot and do not use binaries in wasi-sdk,
-  # so build machine's os and wasi-sdk's host os don't have to be matched
-  WASI_SDK_URL="https://github.com/swiftwasm/wasi-sdk/releases/download/0.2.2-swiftwasm/dist-ubuntu-18.04.zip"
+install_wasi-sysroot() {
+  WASI_SYSROOT_URL="https://github.com/swiftwasm/wasi-sdk-build/releases/download/wasi-sdk-14%2Bswiftwasm-2022-03-13/wasi-sysroot.tar.gz"
 
-  curl -L -o dist-wasi-sdk.zip "$WASI_SDK_URL"
-  unzip -u dist-wasi-sdk.zip -d .
+  curl -L "$WASI_SYSROOT_URL" | tar xz
 
-  WASI_SDK_TAR_PATH=$(find . -type f -name "wasi-sdk-*")
-  WASI_SDK_FULL_NAME=$(basename "$WASI_SDK_TAR_PATH" -linux.tar.gz)
-  tar xfz "$WASI_SDK_TAR_PATH"
-
-  rm -rf "$BUILD_SDK_PATH/wasi-sdk"
-  mv "$WASI_SDK_FULL_NAME" "$BUILD_SDK_PATH/wasi-sdk"
+  mv "wasi-sysroot" "$BUILD_SDK_PATH/wasi-sysroot"
 }
 
 workdir=$(mktemp -d)
@@ -48,6 +40,6 @@ if [ ! -e "$BUILD_SDK_PATH/icu" ]; then
   install_icu
 fi
 
-if [ ! -e "$BUILD_SDK_PATH/wasi-sdk" ]; then
-  install_wasi-sdk
+if [ ! -e "$BUILD_SDK_PATH/wasi-sysroot" ]; then
+  install_wasi-sysroot
 fi

--- a/utils/webassembly/static-executable-args.lnk
+++ b/utils/webassembly/static-executable-args.lnk
@@ -7,7 +7,8 @@
 -lstdc++
 -lm
 -lwasi-emulated-mman
+-lwasi-emulated-signal
+-lwasi-emulated-process-clocks
 -Xlinker --error-limit=0
 -Xlinker --no-gc-sections
 -Xlinker --threads=1
--D_WASI_EMULATED_MMAN


### PR DESCRIPTION
Use the upstream artifact instead of our own fork for maintainability,
and apply some patches to insert fake pthread.h in install-build-sdk.sh,
which was done in our fork.