### PR TITLE
Use Yams 5.0.1 to fix Ubuntu 18.04 build

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -150,7 +150,7 @@
                 "swift-xcode-playground-support": "release/5.7",
                 "ninja": "release",
                 "icu": "release-65-1",
-                "yams": "4.0.2",
+                "yams": "5.0.1",
                 "cmake": "v3.19.6",
                 "indexstore-db": "release/5.7",
                 "sourcekit-lsp": "release/5.7",

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -150,7 +150,7 @@
                 "swift-xcode-playground-support": "release/5.7",
                 "ninja": "release",
                 "icu": "release-65-1",
-                "yams": "5.0.0",
+                "yams": "4.0.2",
                 "cmake": "v3.19.6",
                 "indexstore-db": "release/5.7",
                 "sourcekit-lsp": "release/5.7",


### PR DESCRIPTION
Currently, as can be seen from logs at https://github.com/swiftwasm/swift/runs/6178363121?check_suite_focus=true compilation of Yams 5.0.0 fails with this error:

```
/home/runner/work/swift/swift/yams/Sources/Yams/YamlError.swift  -Xlinker -soname -Xlinker libYams.so  -L /home/runner/work/swift/swift/host-build/Ninja-Release/swiftpm-linux-x86_64/x86_64-unknown-linux-gnu/yams/lib  -L /home/runner/work/swift/swift/host-build/Ninja-Release/foundation-linux-x86_64/lib   -L /usr/lib/gcc/x86_64-linux-gnu/7 -Xlinker -rpath -Xlinker /home/runner/work/swift/swift/host-build/Ninja-Release/foundation-linux-x86_64/lib:  lib/libCYaml.a  -ldispatch  /home/runner/work/swift/swift/host-build/Ninja-Release/foundation-linux-x86_64/lib/libFoundation.so  -lswiftDispatch  -lgcc  -lgcc_s  -lc  -lgcc  -lgcc_s && :
/usr/bin/ld.gold: error: lib/libCYaml.a(api.c.o): requires dynamic R_X86_64_PC32 reloc against 'yaml_realloc' which may overflow at runtime; recompile with -fPIC
/usr/bin/ld.gold: error: lib/libCYaml.a(scanner.c.o): requires dynamic R_X86_64_PC32 reloc against 'yaml_parser_fetch_more_tokens' which may overflow at runtime; recompile with -fPIC
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
```