### PR TITLE
Enable distributed actors in development snapshots

### DIFF
--- a/utils/webassembly/build-presets.ini
+++ b/utils/webassembly/build-presets.ini
@@ -9,6 +9,7 @@ swift-darwin-supported-archs=%(HOST_ARCHITECTURE)s
 compiler-vendor=swiftwasm
 enable-experimental-concurrency=1
 enable-experimental-differentiable-programming=1
+enable-experimental-distributed=1
 
 [preset: webassembly-install]
 

--- a/utils/webassembly/build-toolchain.sh
+++ b/utils/webassembly/build-toolchain.sh
@@ -136,6 +136,7 @@ build_target_toolchain() {
     -D SWIFT_WASI_wasm32_ICU_I18N="$BUILD_SDK_PATH/icu/lib/libicui18n.a" \
     -D SWIFT_WASI_wasm32_ICU_DATA="$BUILD_SDK_PATH/icu/lib/libicudata.a" \
     -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES \
+    -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES \
     -G Ninja \
     -S "$SOURCE_PATH/swift"
 


### PR DESCRIPTION
This would potentially allow us to implement a distributed actors runtime with WebAssembly clients communicating via RPC with other clients or servers written in Swift.