### PR TITLE
[WebAssembly][Runtime] Scan metadata sections for Distribtued and Multi-payload enum

### DIFF
--- a/stdlib/public/runtime/SwiftRT-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-WASM.cpp
@@ -34,6 +34,8 @@ DECLARE_SWIFT_SECTION(swift5_replace)
 DECLARE_SWIFT_SECTION(swift5_replac2)
 DECLARE_SWIFT_SECTION(swift5_builtin)
 DECLARE_SWIFT_SECTION(swift5_capture)
+DECLARE_SWIFT_SECTION(swift5_mpenum)
+DECLARE_SWIFT_SECTION(swift5_accessible_functions)
 }
 
 #undef DECLARE_SWIFT_SECTION
@@ -67,6 +69,8 @@ static void swift_image_constructor() {
       SWIFT_SECTION_RANGE(swift5_replac2),
       SWIFT_SECTION_RANGE(swift5_builtin),
       SWIFT_SECTION_RANGE(swift5_capture),
+      SWIFT_SECTION_RANGE(swift5_mpenum),
+      SWIFT_SECTION_RANGE(swift5_accessible_functions),
   };
 
 #undef SWIFT_SECTION_RANGE


### PR DESCRIPTION
They were just forgotten and not caught by test/stdlib test suite