### PR TITLE
Partially revert "[WASM] Fix test/stdlib/VarArgs.swift"

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -847,7 +847,7 @@ namespace {
         }
 
         static const llvm::StringLiteral vaListNames[] = {
-          "va_list", "__gnuc_va_list", "__isoc_va_list", "__va_list"
+          "va_list", "__gnuc_va_list", "__va_list"
         };
 
         ImportHint hint = ImportHint::None;

--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -128,7 +128,6 @@ MAP_STDLIB_TYPE("u_int64_t", UnsignedInt, 64, "UInt64", false, DoNothing)
 // There's an explicit workaround in ImportType.cpp's VisitDecayedType for that.
 MAP_STDLIB_TYPE("va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__gnuc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
-MAP_STDLIB_TYPE("__isoc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 
 // libkern/OSTypes.h types.


### PR DESCRIPTION
This reverts a compiler part of commit c74876ab8f79d3a9defe1a3aac55cb9b5f8fc0f6.