### PR TITLE
[wasm] Revert GOT direction in IRGen

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3783,12 +3783,6 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity) {
     return {gotEquivalent, ConstantReference::Indirect};
   };
   
-  // Avoid to create GOT because wasm32 doesn't support
-  // dynamic linking yet
-  if (TargetInfo.OutputObjectFormat == llvm::Triple::Wasm) {
-    return direct();
-  }
-
   // Dynamically replaceable function keys are stored in the GlobalVars
   // table, but they don't have an associated Decl, so they require
   // special treatment here.


### PR DESCRIPTION
Let's check if the change is essentially required to port. Revert a part of 4c745a88e10e0ee7c9b3129a7c4250d7f295ea9e