### PR TITLE
[stdlib] Fix calling convention mismatch for debugger utility functions

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -194,13 +194,10 @@ void swift_nonatomic_release_n(HeapObject *object, uint32_t n);
 
 // Refcounting observation hooks for memory tools. Don't use these.
 SWIFT_RUNTIME_EXPORT
-SWIFT_CC(swift)
 size_t swift_retainCount(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-SWIFT_CC(swift)
 size_t swift_unownedRetainCount(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-SWIFT_CC(swift)
 size_t swift_weakRetainCount(HeapObject *object);
 
 /// Is this pointer a non-null unique reference to an object?

--- a/stdlib/public/SwiftShims/swift/shims/HeapObject.h
+++ b/stdlib/public/SwiftShims/swift/shims/HeapObject.h
@@ -81,25 +81,17 @@ struct HeapObject {
 #ifdef __cplusplus
 extern "C" {
 #endif
-#if __has_attribute(swiftcall)
-#define SWIFT_CC_swift __attribute__((swiftcall))
-#else
-#define SWIFT_CC_swift
-#endif
 
 SWIFT_RUNTIME_STDLIB_API
 void _swift_instantiateInertHeapObject(void *address,
                                        const HeapMetadata *metadata);
 
-SWIFT_CC_swift
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t swift_retainCount(HeapObject *obj);
 
-SWIFT_CC_swift
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t swift_unownedRetainCount(HeapObject *obj);
 
-SWIFT_CC_swift
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t swift_weakRetainCount(HeapObject *obj);
 

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -269,9 +269,12 @@ public func _stringForPrintObject(_ value: Any) -> String {
 public func _debuggerTestingCheckExpect(_: String, _: String) { }
 
 // Utilities to get refcount(s) of class objects.
-@_silgen_name("swift_retainCount")
-public func _getRetainCount(_ Value: AnyObject) -> UInt
-@_silgen_name("swift_unownedRetainCount")
-public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt
-@_silgen_name("swift_weakRetainCount")
-public func _getWeakRetainCount(_ Value: AnyObject) -> UInt
+public func _getRetainCount(_ Value: AnyObject) -> UInt {
+  return UInt(swift_retainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+}
+public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt {
+  return UInt(swift_unownedRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+}
+public func _getWeakRetainCount(_ Value: AnyObject) -> UInt {
+  return UInt(swift_weakRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+}


### PR DESCRIPTION
Cherry-pick 8addaa1d85ba6750d500373b55bd9451e869c8e6